### PR TITLE
clang_complete makes other plugin fail when .clang_complete file isn't readable

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -93,7 +93,7 @@ let s:plugin_path = escape(expand('<sfile>:p:h'), '\')
 function! s:ClangCompleteInit()
   let l:local_conf = findfile('.clang_complete', '.;')
   let b:clang_user_options = ''
-  if l:local_conf != ''
+  if l:local_conf != '' && filereadable(l:local_conf)
     let l:opts = readfile(l:local_conf)
     for l:opt in l:opts
       " Better handling of absolute path


### PR DESCRIPTION
When using the :Gdiff command from fugitive, findfile() in ClangCompleteInit() returns a path to a .clang_complete file that is just plain wrong. When readfile() tries to load it it fails and throws an exception, which interrupts everything that was currently done.

This is a bug in vim, but in the meantime an easy fix is to check that the file is readable, so I did it.
