### PR TITLE
Fix cursor moving in case clang_auto_select is enabled

### DIFF
--- a/README
+++ b/README
@@ -4,6 +4,11 @@ How-to use it? Simply put it on ~/.vim/plugin
 It should work immediately.
 
 Configuration:
+  - g:clang_auto_select:
+       if equal to 1, automatically select the first entry in the popup
+       menu
+       Default: 0
+
   - g:clang_complete_auto:
        if equal to 1, automatically complete after ->, ., ::
        Default: 1

--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -684,7 +684,7 @@ function! s:LaunchCompletion()
       let l:result = "\<C-X>\<C-U>\<C-P>"
     endif
     if g:clang_auto_select == 1
-      let l:result .= "\<Down>"
+      let l:result .= "\<C-R>=(pumvisible() ? \"\\<Down>\" : '')\<CR>"
     endif
   endif
   return l:result


### PR DESCRIPTION
In case no completion candidates are found and clang_auto_select is enabled, the cursor will move down one line. Similarly, in case only one completion candidate is found and completeopt is set to 'menu' instead of 'menuone', the cursor will move down one line. This commit fixes these issues.
