### PR TITLE
Handle quoted text in clang_user_options when using libclang.

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -354,7 +354,7 @@ kinds = dict({                                                                 \
                                                                                \
 # Preprocessing                                                                \
 500 : '500', # CXCursor_PreprocessingDirective                                 \
-501 : 'm',   # CXCursor_MacroDefinition                                        \
+501 : 'd',   # CXCursor_MacroDefinition                                        \
 502 : '502', # CXCursor_MacroInstantiation                                     \
 503 : '503'  # CXCursor_InclusionDirective                                     \
 })


### PR DESCRIPTION
Upd.: fixed a typo in libclang.py
