### PR TITLE
Fix for Control-Y fix.

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -650,7 +650,7 @@ function! s:TriggerSnippet()
   endif
 
   " Stop monitoring as we'll trigger a snippet
-  iunmap <buffer> <C-Y>
+  silent! iunmap <buffer> <C-Y>
   augroup ClangComplete
     au! CursorMovedI <buffer>
   augroup end


### PR DESCRIPTION
Omit error message about unmapped Control-Y when TriggerSnippet is called more than once.
