### PR TITLE
Three small changes for clang_complete snippets.

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,4 +1,5 @@
 - Fix snippets engine
+  - map.swap
   - fix const overloads
 - Write some unit tests
   - clang vs libclang accuracy for complex completions


### PR DESCRIPTION
Don't change @/.<br>Don't display cmdline commands.<br>Don't use escape key if already in normal mode.
