### PR TITLE
Include informational and fatal errors to the diagnostic list.

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -89,9 +89,15 @@ def getQuickFix(diagnostic):
   else:
     filename = ""
 
-  if diagnostic.severity == diagnostic.Warning:
+  if diagnostic.severity == diagnostic.Ignored:
+    type = 'I'
+  elif diagnostic.severity == diagnostic.Note:
+    type = 'I'
+  elif diagnostic.severity == diagnostic.Warning:
     type = 'W'
   elif diagnostic.severity == diagnostic.Error:
+    type = 'E'
+  elif diagnostic.severity == diagnostic.Fatal:
     type = 'E'
   else:
     return None


### PR DESCRIPTION
This fixes [Issue 79](https://github.com/Rip-Rip/clang_complete/issues/79)
