### PR TITLE
Fix return code of cc_args.py

### DIFF
--- a/bin/cc_args.py
+++ b/bin/cc_args.py
@@ -76,6 +76,9 @@ result = mergeLists(configuration, args)
 writeConfiguration(map(lambda x: x + "\n", result))
 
 
-sys.exit(os.system(" ".join(sys.argv[1:])))
+status = os.system(" ".join(sys.argv[1:]))
+if not os.WIFEXITED(status):
+  sys.exit(1)
+sys.exit(os.WEXITSTATUS(status))
 
 # vim: set ts=2 sts=2 sw=2 expandtab :


### PR DESCRIPTION
Used to return signal number that killed child process, now returns exit code or 1 if child process is killed by a signal.
