### PR TITLE
Add ; at the end on functions returning void

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -397,10 +397,10 @@ function! s:DemangleProto(prototype)
   let l:proto = substitute(l:proto, '<#', '', 'g')
   let l:proto = substitute(l:proto, '{#.*#}', '', 'g')
   if l:retval == '[#void#]' && len(getline('.')) < col('.')
-    if &filetype =~ '\cobjc'
-      return l:proto.'];'
-    else
+    if &filetype !~ '\cobjc'
       return l:proto.';'
+    else
+      return l:proto
     endif
   else
     return l:proto

--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -198,9 +198,7 @@ def formatResult(result):
 
   if returnStr.strip(' ') == 'void' and \
       vim.eval("len(getline('.')) < col('.')") == '1':
-    if re.match('objc', vim.eval("&ft"), re.I):
-      completion['info'] += '];'
-    else:
+    if not re.match('objc', vim.eval('&ft'), re.I):
       completion['info'] += ';'
 
   # Replace the number that represents a specific kind with a better


### PR DESCRIPTION
I don't like typing A;jj every time I use function returning void.

The only drawback is that one can obtain ;; sometimes (if current line already contains a semicolon).  So you decide if this worth merging.
