### PR TITLE
libclang: Parse file on load to fill caches.

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -227,6 +227,7 @@ function! s:initClangCompletePython()
   exe 'python sys.path = ["' . s:plugin_path . '"] + sys.path'
   exe 'pyfile ' . s:plugin_path . '/libclang.py'
   python initClangComplete(vim.eval('g:clang_complete_lib_flags'))
+  python WarmupCache()
 endfunction
 
 function! s:GetKind(proto)


### PR DESCRIPTION
As soon as a new file is opened, we compile it in the background. This
allows clang to fill its caches, such that the first user completion
happens already on a cached file. This significantly speeds up the first
completion.
