### PR TITLE
Adds `tags' to .gitignore file, useful with pathogen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 *.vba
+tags


### PR DESCRIPTION
Ignore `tags' files created when using pathogen.

I use pathogen with Vim and I use git submodules to track some Vim plugins and when I start Vim, all the tags files are created in the doc/ directory of each plugin, and if some .gitignore of some plugin haven't the `tags' file ignores, it shows untrucked file in my vim config, which is another git repo.

So, I think is nice this commit for all pathogen users using git submodules like me :-)

By the way, I love your clang_complete plugin!

Thanks
