### PR TITLE
Update cindex.py (Second try)

### DIFF
--- a/plugin/clang/cindex.py
+++ b/plugin/clang/cindex.py
@@ -1490,7 +1490,6 @@ class TranslationUnit(ClangObject):
                                            options)
         if ptr:
             return CodeCompletionResults(ptr)
-
         return None
 
 class Index(ClangObject):


### PR DESCRIPTION
This patchset syncs our version of cindex.py with the one in the official clang svn. It does not perform any changes to clang_complete, such that it should be very easy to review.

The main concern regarding this update is that we will not support any libclang
version older than the upcoming clang-3.0 or the current clang development version. Older versions will fail, as parts of the newer functionality is not yet available. As clang-2.9 still had performance issues and we did not release any libclang enabled version of clang_complete yet, I think this is the way to go. Especially as these updates allow us to do a lot of nice stuff (coming later).
