### PR TITLE
Fix threading race condition

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -18,10 +18,7 @@ def getCurrentFile():
   file = "\n".join(vim.eval("getline(1, '$')"))
   return (vim.current.buffer.name, file)
 
-def getCurrentTranslationUnit(args, update = False):
-  currentFile = getCurrentFile()
-  fileName = vim.current.buffer.name
-
+def getCurrentTranslationUnit(args, currentFile, fileName, update = False):
   if fileName in translationUnits:
     tu = translationUnits[fileName]
     if update:
@@ -153,14 +150,14 @@ def updateCurrentDiagnostics():
   userOptionsGlobal = splitOptions(vim.eval("g:clang_user_options"))
   userOptionsLocal = splitOptions(vim.eval("b:clang_user_options"))
   args = userOptionsGlobal + userOptionsLocal
-  getCurrentTranslationUnit(args, update = True)
+  getCurrentTranslationUnit(args, getCurrentFile(),
+                          vim.current.buffer.name, update = True)
 
-def getCurrentCompletionResults(line, column, args):
-  tu = getCurrentTranslationUnit(args)
-  currentFile = getCurrentFile()
+def getCurrentCompletionResults(line, column, args, currentFile, fileName):
+  tu = getCurrentTranslationUnit(args, currentFile, fileName)
   if debug:
     start = time.time()
-  cr = tu.codeComplete(vim.current.buffer.name, line, column, [currentFile],
+  cr = tu.codeComplete(fileName, line, column, [currentFile],
       complete_flags)
   if debug:
     elapsed = (time.time() - start)
@@ -200,10 +197,12 @@ def formatResult(result):
 class CompleteThread(threading.Thread):
   lock = threading.Lock()
 
-  def __init__(self, line, column):
+  def __init__(self, line, column, currentFile, fileName):
     threading.Thread.__init__(self)
     self.line = line
     self.column = column
+    self.currentFile = currentFile
+    self.fileName = fileName
     self.result = None
     userOptionsGlobal = splitOptions(vim.eval("g:clang_user_options"))
     userOptionsLocal = splitOptions(vim.eval("b:clang_user_options"))
@@ -219,10 +218,10 @@ class CompleteThread(threading.Thread):
         # Otherwise we would get: E293: block was not locked
         # The user does not see any delay, as we just pause a background thread.
         time.sleep(0.1)
-        getCurrentTranslationUnit(self.args)
+        getCurrentTranslationUnit(self.args, self.currentFile, self.fileName)
       else:
         self.result = getCurrentCompletionResults(self.line, self.column,
-                                                  self.args)
+                                          self.args, self.currentFile, self.fileName)
     except Exception:
       pass
     CompleteThread.lock.release()
@@ -230,7 +229,7 @@ class CompleteThread(threading.Thread):
 def WarmupCache():
   global debug
   debug = int(vim.eval("g:clang_debug")) == 1
-  t = CompleteThread(-1, -1)
+  t = CompleteThread(-1, -1, getCurrentFile(), vim.current.buffer.name)
   t.start()
   return
 
@@ -242,7 +241,7 @@ def getCurrentCompletions(base):
   line = int(vim.eval("line('.')"))
   column = int(vim.eval("b:col"))
 
-  t = CompleteThread(line, column)
+  t = CompleteThread(line, column, getCurrentFile(), vim.current.buffer.name)
   t.start()
   while t.isAlive():
     t.join(0.01)


### PR DESCRIPTION
Due to a race condition the `getline` call in `getCurrentFile()` can end up accessing the wrong buffer, potentially causing a segfault. This patch fixes it by getting the buffer data from the Vim thread instead.

More information in this thread:
http://groups.google.com/group/vim_dev/browse_thread/thread/11202170590cdeaa
