### PR TITLE
Hides `doautocmd QuickFixCmdPost make' annoying message

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -317,7 +317,7 @@ function! s:ClangQuickFix(clang_output, tempfname)
     exe l:winbufnr . 'wincmd w'
   endif
   call setqflist(l:list)
-  doautocmd QuickFixCmdPost make
+  silent doautocmd QuickFixCmdPost make
 endfunction
 
 function! s:ClangUpdateQuickFix(clang_output, tempfname)


### PR DESCRIPTION
When doing `doautocmd QuickFixCmdPost make', if no autocommands are
registered for QuickFixCmdPost, that annoying message is shown, we need
to add`:silent'.

Closes #96
