### PR TITLE
Include "info" diagnostic messages (for clang executable mode)

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -323,7 +323,7 @@ endfunction
 function! s:ClangUpdateQuickFix(clang_output, tempfname)
   let l:list = []
   for l:line in a:clang_output
-    let l:erridx = match(l:line, '\%(error\|warning\): ')
+    let l:erridx = match(l:line, '\%(error\|warning\|note\): ')
     if l:erridx == -1
       " Error are always at the beginning.
       if l:line[:11] == 'COMPLETION: ' || l:line[:9] == 'OVERLOAD: '
@@ -345,10 +345,14 @@ function! s:ClangUpdateQuickFix(clang_output, tempfname)
       let l:text = l:line[l:erridx + 7:]
       let l:type = 'E'
       let l:hlgroup = ' SpellBad '
-    else
+    elseif l:line[l:erridx] == 'w'
       let l:text = l:line[l:erridx + 9:]
       let l:type = 'W'
       let l:hlgroup = ' SpellLocal '
+    else
+      let l:text = l:line[l:erridx + 6:]
+      let l:type = 'I'
+      let l:hlgroup = ' '
     endif
     let l:item = {
           \ 'bufnr': l:bufnr,
@@ -358,7 +362,7 @@ function! s:ClangUpdateQuickFix(clang_output, tempfname)
           \ 'type': l:type }
     let l:list = add(l:list, l:item)
 
-    if g:clang_hl_errors == 0 || l:fname != '%'
+    if g:clang_hl_errors == 0 || l:fname != '%' || l:type == 'I'
       continue
     endif
 


### PR DESCRIPTION
I previously submitted a patch to add the "info" diagnostics when using libclang.  This patch does the same thing for non-libclang mode.

Here's some code to try this patch on:

```
template <class T> class A {
    typedef T::type x;
};

A<int> a;
```

With this fix, the diagnostic results are:

```
test.cpp|2 col 13 error| missing 'typename' prior to dependent type name 'T::type'
test.cpp|2 col 13 error| type 'int' cannot be used prior to '::' because it has no members
test.cpp|5 col 8 info| in instantiation of template class 'A<int>' requested here
```

(Before this patch, the last entry doesn't exist).
