### PR TITLE
More accurate .clang_complete parsing

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -176,17 +176,23 @@ function! s:parseConfig()
     return
   endif
 
+  let l:root = substitute(fnamemodify(l:local_conf, ':p:h'), '\', '/', 'g')
+
   let l:opts = readfile(l:local_conf)
   for l:opt in l:opts
-    " Better handling of absolute path
-    " I don't know if those pattern will work on windows
-    " platform
+    " Use forward slashes only
+    let l:opt = substitute(l:opt, '\', '/', 'g')
+    " Handling of absolute path
     if matchstr(l:opt, '\C-I\s*/') != ''
       let l:opt = substitute(l:opt, '\C-I\s*\(/\%(\w\|\\\s\)*\)',
             \ '-I' . '\1', 'g')
+    " Check for win32 is enough since it's true on win64
+    elseif has('win32') && matchstr(l:opt, '\C-I\s*[a-zA-Z]:/') != ''
+      let l:opt = substitute(l:opt, '\C-I\s*\([a-zA-Z:]/\%(\w\|\\\s\)*\)',
+            \ '-I' . '\1', 'g')
     else
-      let l:opt = substitute(l:opt, '\C-I\s*\(\%(\w\|\\\s\)*\)',
-            \ '-I' . l:local_conf[:-16] . '\1', 'g')
+      let l:opt = substitute(l:opt, '\C-I\s*\(\%(\w\|\.\|/\|\\\s\)*\)',
+            \ '-I' . l:root . '/\1', 'g')
     endif
     let b:clang_user_options .= ' ' . l:opt
   endfor


### PR DESCRIPTION
I recently figured out that absolute path in .clang_complete don't work for me on Windows when .clang_complete is not in the same directory where source file is.  So I fixed that and some related issues (yes, this description has more lines than were changed in clang_complete.vim :) ):
-   usage of forward slashes (issue #111) (my is related to this item, because substitution argument of `substitute()` could became something like '-Ie:\foo\bar\\1', note two consecutive slashes)
-   making include path absolute when .clang_complete is in the same directory as the source file (and `findfile()` returns relative path)
-   substitution command for relative path, that stopped matching after trapping on dot or slash character
-   relative paths converted to absolute lacked drive letter on Windows
