### PR TITLE
Ignore c.cache file, useful with Pathogen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.vba
+*.cache
 tags


### PR DESCRIPTION
Useful when using Pathogen (https://github.com/tpope/vim-pathogen) to keep your vim config repository clean.
