### PR TITLE
Speedup code completion results.

### DIFF
--- a/doc/clang_complete.txt
+++ b/doc/clang_complete.txt
@@ -170,7 +170,8 @@ Default: ""
 
 					*clang_complete-sort_algo*
 					*g:clang_sort_algo*
-How results are sorted (alpha, priority). Currently only works with libclang.
+How results are sorted (alpha, priority, none). Currently only works with
+libclang.
 Default: "priority"
 
 					*clang_complete-complete_macros*

--- a/examples/boost.cpp
+++ b/examples/boost.cpp
@@ -13,6 +13,6 @@
 
 int main()
 {
-	boost:
+	boost::matc
 	//     ^ Code complete here by typing ":"
 }

--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -254,7 +254,7 @@ def WarmupCache():
 def getCurrentCompletions(base):
   global debug
   debug = int(vim.eval("g:clang_debug")) == 1
-  priority = vim.eval("g:clang_sort_algo") == 'priority'
+  sorting = vim.eval("g:clang_sort_algo")
   line = int(vim.eval("line('.')"))
   column = int(vim.eval("b:col"))
 
@@ -278,10 +278,10 @@ def getCurrentCompletions(base):
     regexp = re.compile("^" + base)
     results = filter(lambda x: regexp.match(getAbbr(x.string)), results)
 
-  if priority:
+  if sorting == 'priority':
     getPriority = lambda x: x.string.priority
     results = sorted(results, None, getPriority)
-  else:
+  if sorting == 'alpha':
     getAbbrevation = lambda x: getAbbr(x.string).lower()
     results = sorted(results, None, getAbbrevation)
 


### PR DESCRIPTION
This patch set speeds up our post processing of the code completion
results. For the newly add test file 'examples/boost.cpp', it changes the overall completion time from 0.42 to 0.322 or even 0.28 seconds (without sorting results). The time spent in clang is here 0.23 seconds so our overhead is reduced from 0.19 seconds to 0.09 (0.05) seconds. This is a 2x (4x) speedup.

(This is not entirely true. The timings were obtained with a new version of the libclang bindings. As, those bindings still need to be reviewed and this will take some time, I decided to push out this improvements separately. For the current bindings I get a speedup from 0.63 to 0.41 seconds. Still very good, but with the new bindings another 25% speedup can be achieved.)
