### PR TITLE
Correctly execute the command passed to cc_args.py

### DIFF
--- a/bin/cc_args.py
+++ b/bin/cc_args.py
@@ -76,9 +76,12 @@ result = mergeLists(configuration, args)
 writeConfiguration(map(lambda x: x + "\n", result))
 
 
-status = os.system(" ".join(sys.argv[1:]))
-if not os.WIFEXITED(status):
+import subprocess
+proc = subprocess.Popen(sys.argv[1:])
+ret = proc.wait()
+
+if ret is None:
   sys.exit(1)
-sys.exit(os.WEXITSTATUS(status))
+sys.exit(ret)
 
 # vim: set ts=2 sts=2 sw=2 expandtab :


### PR DESCRIPTION
The original command line passed to cc_args.py program was losing shell
escaping sequences. For instance, if one would execute the following
command

`$ cc_args.py gcc -DVERSION=\"0.1.0\" ...`

the command would first be unescaped by the shell and then cc_args.py
would execute

`$ gcc -DVERSION="0.1.0" ...`

which is incorrect. With this patch, cc_args.py uses Python's subprocess
module, which executes correctly.
