### PR TITLE
Add OmniCppComplete compatibility mode

### DIFF
--- a/doc/clang_complete.txt
+++ b/doc/clang_complete.txt
@@ -26,7 +26,11 @@ This plugin use clang for accurately completing C and C++ code.
 
 Note: This plugin is incompatible with omnicppcomplete due to the
 unconditionnaly set mapping done by omnicppcomplete. So don't forget to
-suppress it before using this plugin.
+suppress it before using this plugin. Also it's possible to keep
+omnicppcomplete plugin enabled by setting |g:clang_omnicppcomplete_compliance|.
+in this case it will be possible to use omnicppcomplete in parallel with
+clang_complete, though functionality of the latter will be reduced to
+<C-X><C-U> only.
 
 ==============================================================================
 2. Completion kinds    				*clang_complete-compl_kinds*
@@ -189,6 +193,13 @@ Default: 0
 					*clang_complete-complete_patterns*
 					*g:clang_complete_patterns*
 If clang should complete code patterns, i.e loop constructs etc.
+Defaut: 0
+
+					*clang_complete-omnicppcomplete_compliance*
+					*g:clang_omnicppcomplete_compliance*
+Omnicppcomplete compatibility mode. Keeps omni auto-completion in control of
+omnicppcomplete, disables clang's auto-completion (|g:clang_complete_auto|)
+and enables only <C-X><C-U> as main clang completion function.
 Defaut: 0
 
 ==============================================================================

--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -83,13 +83,24 @@ function! s:ClangCompleteInit()
     let g:clang_auto_user_options = 'path, .clang_complete, gcc'
   endif
 
+  if !exists('g:clang_omnicppcomplete_compliance')
+    let g:clang_omnicppcomplete_compliance = 0
+  endif
+
   call LoadUserOptions()
 
+  if g:clang_omnicppcomplete_compliance != 0
+    let g:clang_complete_auto = 0
+  endif
+
   inoremap <expr> <buffer> <C-X><C-U> <SID>LaunchCompletion()
-  inoremap <expr> <buffer> . <SID>CompleteDot()
-  inoremap <expr> <buffer> > <SID>CompleteArrow()
-  inoremap <expr> <buffer> : <SID>CompleteColon()
-  inoremap <expr> <buffer> <CR> <SID>HandlePossibleSelectionEnter()
+
+  if g:clang_omnicppcomplete_compliance == 0
+    inoremap <expr> <buffer> . <SID>CompleteDot()
+    inoremap <expr> <buffer> > <SID>CompleteArrow()
+    inoremap <expr> <buffer> : <SID>CompleteColon()
+    inoremap <expr> <buffer> <CR> <SID>HandlePossibleSelectionEnter()
+  endif
 
   if g:clang_snippets == 1
     call g:ClangSetSnippetEngine(g:clang_snippets_engine)
@@ -136,7 +147,9 @@ function! s:ClangCompleteInit()
   endif
 
   setlocal completefunc=ClangComplete
-  setlocal omnifunc=ClangComplete
+  if g:clang_omnicppcomplete_compliance == 0
+    setlocal omnifunc=ClangComplete
+  endif
 
   if g:clang_periodic_quickfix == 1
     augroup ClangComplete


### PR DESCRIPTION
Allow clang_complete to be used in parallel with OmniCppComplete, mostly
as an alternative manual-completion method.

In this mode all omni auto-completion is kept in control of
OmniCppComplete plugin, clang's auto-completion is disabled, keeping
only <C-X><C-U> as main clang completion function.

This mode is enabled by g:clang_omnicppcomplete_compliance configuration
option.
