### PR TITLE
The vimball is now a .vmb, not a .vba

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.pyc
-*.vba
+*.vmb
 *.cache
 tags

--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,4 @@ install: clang_complete.vmb
 
 .PHONY: clean
 clean:
-	rm -f clang_complete.vba
+	rm -f clang_complete.vmb

--- a/README
+++ b/README
@@ -5,7 +5,7 @@ $ make install
 
 To build and install in two steps, type:
 $ make
-$ vim clang_complete.vba -c 'so %' -c 'q'
+$ vim clang_complete.vmb -c 'so %' -c 'q'
 
 Alternatively, you can also put the files in ~/.vim/
 


### PR DESCRIPTION
The Makefile, .gitignore and README can be updated to reflect the change from .vba to .vbm
