### PR TITLE
Add an 'uninstall' convenience target to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,11 @@ clang_complete.vmb: $(FILES)
 	     -c '$$,$$d _' \
 	     -c "%MkVimball! $@ ." -c 'q!'
 
-.PHONY: install
+.PHONY: install uninstall
 install: clang_complete.vmb
 	vim $< -c 'so %' -c 'q'
+uninstall:
+	vim -c 'RmVimball clang_complete.vmb' -c 'q'
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Avoid cluterring the .VimballRecord file, and provide an 'uninstall' target
