### PR TITLE
Crash when clang_periodic_quickfix enabled, race with WarmupCache

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -11,6 +11,8 @@ def initClangComplete(clang_complete_flags):
   translationUnits = dict()
   global complete_flags
   complete_flags = int(clang_complete_flags)
+  global libclangLock
+  libclangLock = threading.Lock()
 
 # Get a tuple (fileName, fileContent) for the file opened in the current
 # vim buffer. The fileContent contains the unsafed buffer content.
@@ -150,8 +152,10 @@ def updateCurrentDiagnostics():
   userOptionsGlobal = splitOptions(vim.eval("g:clang_user_options"))
   userOptionsLocal = splitOptions(vim.eval("b:clang_user_options"))
   args = userOptionsGlobal + userOptionsLocal
+  libclangLock.acquire()
   getCurrentTranslationUnit(args, getCurrentFile(),
                           vim.current.buffer.name, update = True)
+  libclangLock.release()
 
 def getCurrentCompletionResults(line, column, args, currentFile, fileName):
   tu = getCurrentTranslationUnit(args, currentFile, fileName)
@@ -212,8 +216,6 @@ def formatResult(result):
 
 
 class CompleteThread(threading.Thread):
-  lock = threading.Lock()
-
   def __init__(self, line, column, currentFile, fileName):
     threading.Thread.__init__(self)
     self.line = line
@@ -227,7 +229,7 @@ class CompleteThread(threading.Thread):
 
   def run(self):
     try:
-      CompleteThread.lock.acquire()
+      libclangLock.acquire()
       if self.line == -1:
         # Warm up the caches. For this it is sufficient to get the current
         # translation unit. No need to retrieve completion results.
@@ -241,7 +243,7 @@ class CompleteThread(threading.Thread):
                                           self.args, self.currentFile, self.fileName)
     except Exception:
       pass
-    CompleteThread.lock.release()
+    libclangLock.release()
 
 def WarmupCache():
   global debug


### PR DESCRIPTION
When opening a file that take a long time for clang to parse, I'm occasionally hitting asserts in libclang about concurrent access, and even sometimes an actual crash of vim.

Turns out if the initial parsing of the file when its opened, triggered by <tt>WarmupCache</tt> (in libclang.py), takes long enough, then if <tt>g:clang_periodic_quickfix</tt> is set, the periodic update of the quickfix window may be triggered before the initial parsing has finished.

Currently there's a lock preventing concurrent accesses when doing actual code completion, but not for updating the quickfix window. This replaces <tt>CompleteThread</tt>'s lock with a global <tt>libclangLock</tt> that is also used by <tt>updateCurrentDiagnotics</tt>

Originally came across this only when using a debug build of clang, but I have since been able to reproduce on a normal build with large enough source files, e.g. the 400k clang/lib/Sema/SemaDecl.cpp from clang's own source code.
