### PR TITLE
Find right libclang.so file on Debian

### DIFF
--- a/plugin/clang/cindex.py
+++ b/plugin/clang/cindex.py
@@ -66,9 +66,6 @@ import sys
 from ctypes import *
 
 def get_cindex_library():
-    # FIXME: It's probably not the case that the library is actually found in
-    # this location. We need a better system of identifying and loading the
-    # CIndex library. It could be on path or elsewhere, or versioned, etc.
     from ctypes.util import find_library
     path = sys.argv[0]
     if path != '':


### PR DESCRIPTION
This is quite hackish, but it does fix the use of libclang.so.1 on Debian, where there is no symlink to plain libclang.so (for now, at least).
