### PR TITLE
Improved integration with UltiSnips

### DIFF
--- a/autoload/snippets/ultisnips.vim
+++ b/autoload/snippets/ultisnips.vim
@@ -2,7 +2,7 @@
 " Author: Philippe Vaucher
 
 function! snippets#ultisnips#init()
-  UltiSnipsAddFiletypes clang_complete
+  UltiSnipsAddFiletypes cpp.clang_complete
   call snippets#ultisnips#reset()
 endfunction
 


### PR DESCRIPTION
I am the author of UltiSnips and I took a quick look at the implementation of clang complete snippet integration with UltiSnips. This commit contains a few fixes:
- Add clang_complete snippets in a pseudo file-type called "clang-complete" which is cleared independently of the other filetypes. This avoids overwriting custom cpp/c/all snippets the user might have written for his own usage.
- Do not call UltiSnips_Manager.reset() for the same reason.

Please merge this if possible, clang_complete generates quite some bug reports on UltiSnips tracker lately.

Really wonderful plugin btw :)
