### PR TITLE
Small fix on integration with UltiSnips

### DIFF
--- a/autoload/snippets/ultisnips.vim
+++ b/autoload/snippets/ultisnips.vim
@@ -2,7 +2,7 @@
 " Author: Philippe Vaucher
 
 function! snippets#ultisnips#init()
-  UltiSnipsAddFiletypes cpp.clang_complete
+  UltiSnipsAddFiletypes &filetype.clang_complete
   call snippets#ultisnips#reset()
 endfunction
 


### PR DESCRIPTION
Hi

With the last commit in the UltiSnips integration `cpp` was harcoded, so with C files all the snippets were duplicated. I just replaced it with `&filetype`, and now everything works fine.
