### PR TITLE
libclangLock got released twice during warmup thread

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -243,7 +243,8 @@ class CompleteThread(threading.Thread):
                                           self.args, self.currentFile, self.fileName)
     except Exception:
       pass
-    libclangLock.release()
+    if libclangLock.locked():
+      libclangLock.release()
 
 def WarmupCache():
   global debug


### PR DESCRIPTION
the libclangLock got released twice during warmup thread, the second
release will incur a exception.

this happens on my win7 box. Whenever I opened a cpp file for the first time, the warmup thread started. But I got a "release unlocked lock exception". 
I noticed that the following behavior:
1. the warmup thread acquired the lock and successes
2. a different thread released the lock, and successes
3. the warmup thread tried  to release the lock, and failed

It's odd, and I tried to fix it by checking the lock state before actually release the lock.
