### PR TITLE
Another small fix to integration with UltiSnips

### DIFF
--- a/autoload/snippets/ultisnips.vim
+++ b/autoload/snippets/ultisnips.vim
@@ -2,7 +2,7 @@
 " Author: Philippe Vaucher
 
 function! snippets#ultisnips#init()
-  UltiSnipsAddFiletypes &filetype.clang_complete
+  exe "UltiSnipsAddFiletypes ".&filetype.".clang_complete"
   call snippets#ultisnips#reset()
 endfunction
 


### PR DESCRIPTION
This is a follow up of pull request #161.  It fixes the command `:UltiSnipsEdit`, which wasn't replacing the variable `&filetype` with the actual filetype (my bad, I didn't try the command before sending the previous request).
