### PR TITLE
Support for setting g:clang_use_library after the plugin has been initialized

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -154,14 +154,7 @@ function! s:ClangCompleteInit()
 
   " Load the python bindings of libclang
   if g:clang_use_library == 1
-    if has('python')
-      call s:initClangCompletePython()
-    else
-      echoe 'clang_complete: No python support available.'
-      echoe 'Cannot use clang library, using executable'
-      echoe 'Compile vim with python support to use libclang'
-      let g:clang_use_library = 0
-    endif
+    call s:TestPythonInit()
   endif
 endfunction
 
@@ -245,6 +238,18 @@ function! s:initClangCompletePython()
     let s:libclang_loaded = 1
   endif
   python WarmupCache()
+endfunction
+
+" A wrapper around initClangCompletePython that checks for python availability
+function! s:TestPythonInit()
+  if has('python')
+    call s:initClangCompletePython()
+  else
+    echoe 'clang_complete: No python support available.'
+    echoe 'Cannot use clang library, using executable'
+    echoe 'Compile vim with python support to use libclang'
+    let g:clang_use_library = 0
+  endif
 endfunction
 
 function! s:GetKind(proto)
@@ -569,6 +574,7 @@ function! ClangComplete(findstart, base)
     endif
 
     if g:clang_use_library == 1
+      call s:TestPythonInit()
       python vim.command('let l:res = ' + str(getCurrentCompletions(vim.eval('a:base'))))
     else
       let l:res = s:ClangCompleteBinary(a:base)


### PR DESCRIPTION
following [issue 158](https://github.com/Rip-Rip/clang_complete/issues/158), I propose a patch to allow the setting of g:clang_use_library after the plugin has been initialized.

The plugin will now try to initialize the python script each time a ClangComplete is called and g:clang_use_library is set to 1.

This is very much a quick and dirty solution, but until vim allows a way to trace variable modification, it provides the easiest workaround.
