### PR TITLE
namespace members completion not working opening a saved file

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -35,7 +35,7 @@ def getCurrentTranslationUnit(args, currentFile, fileName, update = False):
   if debug:
     start = time.time()
   # TranslationUnit.PrecompiledPreamble usage makes completion for members of namespace fail
-  flags = TranslationUnit.Nothing # TranslationUnit.PrecompiledPreamble | TranslationUnit.CXXPrecompiledPreamble | TranslationUnit.CacheCompletionResults
+  flags = TranslationUnit.CacheCompletionResults
   tu = index.parse(fileName, args, [currentFile], flags)
   if debug:
     elapsed = (time.time() - start)


### PR DESCRIPTION
If I create a new file and include a header like `<iostream>` and keep editing this file, the moment I write `std::` I get a lot of members from namespace std.

If I save the file containing the `#include <iostream>`, and open it again, `std::` completion fails and I get a near empty member list, this is what I get:

![namespace completion fail](http://i.imgur.com/GcDE0.png)

even if I don't get member of namespace completion, if I do use a member like `std::cout` at the source code, and try to complete this member members with a `.`, like `std::cout .`, the completion for this member members works.
