### PR TITLE
Correct delay-loading of g:clang_user_options after VIM's initialization

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -224,15 +224,16 @@ class CompleteThread(threading.Thread):
     self.currentFile = currentFile
     self.fileName = fileName
     self.result = None
-    self.args = None
+    self._args = None
 
-  def getArgs(self):
-    if self.args == None:
+  @property
+  def args(self):
+    if self._args == None:
       userOptionsGlobal = splitOptions(vim.eval("g:clang_user_options"))
       userOptionsLocal = splitOptions(vim.eval("b:clang_user_options"))
       parametersLocal = splitOptions(vim.eval("b:clang_parameters"))
-      self.args = userOptionsGlobal + userOptionsLocal + parametersLocal
-    return self.args
+      self._args = userOptionsGlobal + userOptionsLocal + parametersLocal
+    return self._args
 
   def run(self):
     try:
@@ -244,10 +245,10 @@ class CompleteThread(threading.Thread):
         # Otherwise we would get: E293: block was not locked
         # The user does not see any delay, as we just pause a background thread.
         time.sleep(0.5)
-        getCurrentTranslationUnit(self.getArgs(), self.currentFile, self.fileName)
+        getCurrentTranslationUnit(self.args, self.currentFile, self.fileName)
       else:
         self.result = getCurrentCompletionResults(self.line, self.column,
-                                          self.getArgs(), self.currentFile, self.fileName)
+                                          self.args, self.currentFile, self.fileName)
     except Exception:
       pass
     libclangLock.release()


### PR DESCRIPTION
I use the [vimprj](http://www.vim.org/scripts/script.php?script_id=3872) plugin for generic cascade configuration loading for VIM. I realized it was not working with clang_complete because I was using `g:clang_user_options` to configure additional include directories for completion, but it wasn't working.

I figured out clang was parsing `g:clang_user_options` too early, before the `time.sleep(0.1)` for proper VIM initialization in the `CompleteThread`.

The clang arguments are being passed around as a parameter between several functions, but these clang arguments only have usage at the first `index.parse`, the following `reparse`'s will not benefit from new or changed parameters because `reparse` does not accept new ones, it runs based on the first `index.parse` configuration.

So, beyond this quick fix, I think some refactoring on `args` usage would be good. They get initialized once, as a _setting_, so I'm doubting whether it needs to be passed around in function arguments for no use.

I don't like too much configuration files, so I don't use `.clang_complete`'s since I thought vimprj could do that job very well already. It's built just for this functionality of cascade configuration loading and one configuration file for that I think is enough.

This fix makes clang_complete compatible with vimprj and other plugins for that kind of functionality. I'm just setting `g:clang_user_options` in its configuration files in the directory tree to get cascading clang_complete configurations.
