### PR TITLE
Guard against unreadable buffers at initialization

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -18,6 +18,11 @@ let b:my_changedtick = 0
 let s:plugin_path = escape(expand('<sfile>:p:h'), '\')
 
 function! s:ClangCompleteInit()
+  let l:bufname = bufname("%")
+  if l:bufname == '' || !filereadable(l:bufname)
+    return
+  endif
+  
   if !exists('g:clang_auto_select')
     let g:clang_auto_select = 0
   endif


### PR DESCRIPTION
Fix initialization being triggered with unnamed/unreadable buffers,
which was causing parsing of translation units called "None", generating
several error messages.

This was happening calling g:ClangUpdateQuickFix().
