### PR TITLE
Fix continuous QuickFix warning for unused args

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -89,6 +89,8 @@ def getQuickFix(diagnostic):
   elif diagnostic.severity == diagnostic.Note:
     type = 'I'
   elif diagnostic.severity == diagnostic.Warning:
+    if "argument unused during compilation" in diagnostic.spelling:
+      return None
     type = 'W'
   elif diagnostic.severity == diagnostic.Error:
     type = 'E'


### PR DESCRIPTION
Fix continuous QuickFix warning when g:clang_complete_macros or
g:clang_complete_patterns are enabled. This options makes reparse
to generate warning messages for unused arguments.

Warning messages for unused arguments are now being filtered out.
