### PR TITLE
Removes checking whether file is readable for guard against unreadable buffers at initialization

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -19,7 +19,7 @@ let s:plugin_path = escape(expand('<sfile>:p:h'), '\')
 
 function! s:ClangCompleteInit()
   let l:bufname = bufname("%")
-  if l:bufname == '' || !filereadable(l:bufname)
+  if l:bufname == ''
     return
   endif
   


### PR DESCRIPTION
#184 just got merged and I found an issue:

Checking whether file is readable prior to loading clang_complete
is wrong. The plugin can't get loaded on creation of new files.

The correct guard is only to check whether the file name is `''`.

On creating new files they don't start readable.
