### PR TITLE
Update cindex.py up to clang from 01/11/2012

### DIFF
--- a/plugin/clang/cindex.py
+++ b/plugin/clang/cindex.py
@@ -1271,6 +1271,12 @@ class Cursor(Structure):
         # created.
         return self._tu
 
+    def get_arguments(self):
+        """Return an iterator for accessing the arguments of this cursor."""
+        num_args = conf.lib.clang_Cursor_getNumArguments(self)
+        for i in range(0, num_args):
+            yield conf.lib.clang_Cursor_getArgument(self, i)
+
     def get_children(self):
         """Return an iterator for accessing the children of this cursor."""
 
@@ -2973,6 +2979,15 @@ functionList = [
   ("clang_visitChildren",
    [Cursor, callbacks['cursor_visit'], py_object],
    c_uint),
+
+  ("clang_Cursor_getNumArguments",
+   [Cursor],
+   c_int),
+
+  ("clang_Cursor_getArgument",
+   [Cursor, c_uint],
+   Cursor,
+   Cursor.from_result),
 ]
 
 class LibclangError(Exception):


### PR DESCRIPTION
This syncs our cindex.py with the latest version from clang. The new changes fixes some types and
add the following features:
- 'brief' doxygen comments

From the completion results, it is not possible to access the brief doxygen comment of a function.
- AvailibilityKind 'NotAccessible'

It is now possible to understand if a function exists, but is not accessible.

This pull request only adds those features to cindex.py. Support in clang_complete is yet included. The new changes should not cause any incompatibilities with older libclang versions.
