### PR TITLE
Add the option that help us to add the current directory  to include paths recursively

### DIFF
--- a/doc/clang_complete.txt
+++ b/doc/clang_complete.txt
@@ -239,6 +239,17 @@ Default: 0
 If clang should complete code patterns, i.e loop constructs etc.
 Defaut: 0
 
+					*clang_complete-include_current_directory_recursively*
+					g:clang_complete_include_current_directory_recursively
+If clang should include current directory recursively.
+Defaut: 0
+
+					*clang_complete-ignore_include_directories*
+					g:clang_complete_ignore_include_directories
+If you are using g:clang_complete_include_current_directory_recursivel option, 
+this option allows you to specify the directories that you want to ignore. 
+Defaut: ["^\.git", "\.xcodeproj"]
+
 ==============================================================================
 5. Known issues					*clang_complete-issues*
 


### PR DESCRIPTION
I wanted to add the current directory and the sub directories to search paths recursively, so I added the 2 options.  

```
# If clang should include current directory recursively.
let g:clang_complete_include_current_directory_recursively = 1
```

```
# If you are using g:clang_complete_include_current_directory_recursivel option, 
# this option allows you to specify the directories that you want to ignore. 
let g:clang_complete_ignore_include_directories = ["^\.git", "\.xcodeproj"]
```
