### PR TITLE
Only enable the Warmup cache when debug is enabled for now.

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -437,8 +437,9 @@ class CompleteThread(threading.Thread):
 def WarmupCache():
   global debug
   debug = int(vim.eval("g:clang_debug")) == 1
-  t = CompleteThread(-1, -1, getCurrentFile(), vim.current.buffer.name)
-  t.start()
+  if debug:
+    t = CompleteThread(-1, -1, getCurrentFile(), vim.current.buffer.name)
+    t.start()
 
 
 def getCurrentCompletions(base):


### PR DESCRIPTION
On issue #216, the code doesn't seems to be executed in background, but at exit time...
