### PR TITLE
Speed up libclang, take two.

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -143,8 +143,8 @@ class CodeCompleteTimer:
     print " "
 
 def getCurrentTranslationUnit(args, currentFile, fileName, update = False):
-  if fileName in translationUnits:
-    tu = translationUnits[fileName]
+  tu = translationUnits.get(fileName)
+  if tu != None:
     if update:
       if debug:
         start = time.time()


### PR DESCRIPTION
Here is some milliseconds saved. I'm however starting to be out of idea :). The only one I could see would involve rewriting formatResult and changing the snippets API.

There is actually another way: use CompleteDone autocmd, but it's too young and not mature (we cannot get the whole dict of the selected completion).
