### PR TITLE
Snippet performance improvements

### DIFF
--- a/autoload/snippets/clang_complete.vim
+++ b/autoload/snippets/clang_complete.vim
@@ -47,6 +47,17 @@ endfunction
 function! snippets#clang_complete#reset()
 endfunction
 
+python << endpython
+def snippets__clang_complete__formatSnippet(word):
+  return "<#" + word + "#>"
+
+def snippets__clang_complete__trailingPlaceholder():
+  trailingPlaceholder = int(vim.eval("g:clang_trailing_placeholder")) == 1
+  if trailingPlaceholder:
+    return "<##>"
+  else:
+    return ""
+endpython
 
 " ---------------- Helpers ----------------
 

--- a/autoload/snippets/dummy.vim
+++ b/autoload/snippets/dummy.vim
@@ -22,3 +22,14 @@ endfunction
 function! snippets#dummy#reset()
   echo 'Resetting all snippets'
 endfunction
+
+" Python functions to speed up snippet handling
+python << endpython
+def snippets__dummy__formatSnippet(word):
+  print "Creating snippet for placeholder " + word
+  return word
+
+def snippets__dummy__trailingPlaceholder():
+  print 'Trailing placeholder is ""'
+  return ""
+endpython

--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -340,7 +340,7 @@ def getCurrentCompletionResults(line, column, args, currentFile, fileName,
   timer.registerEvent("Code Complete")
   return cr
 
-def formatResult(result):
+def formatResultPlain(result):
   completion = dict()
   returnValue = None
   abbr = ""
@@ -377,6 +377,55 @@ def formatResult(result):
   completion['abbr'] = abbr
   completion['menu'] = menu
   completion['info'] = word
+  completion['args_pos'] = args_pos
+  completion['dup'] = 1
+
+  # Replace the number that represents a specific kind with a better
+  # textual representation.
+  completion['kind'] = kinds[result.cursorKind]
+
+  return completion
+
+def formatResultSnippets(result, formatSnippet, trailingPlaceholder):
+  completion = dict()
+  returnValue = None
+  abbr = ""
+  args_pos = []
+  cur_pos = 0
+  word = ""
+  info = ""
+
+  for chunk in result.string:
+    if chunk.isKindInformative():
+      continue
+
+    if chunk.isKindResultType():
+      returnValue = chunk
+      continue
+
+    chunk_spelling = chunk.spelling
+
+    if chunk.isKindTypedText():
+      abbr = chunk_spelling
+
+    if chunk.isKindPlaceHolder():
+      word += formatSnippet(chunk_spelling)
+    else:
+      word += chunk_spelling
+
+    info += chunk_spelling
+
+  menu = info
+
+  if returnValue:
+    menu = returnValue.spelling + " " + menu
+
+  word += trailingPlaceholder
+
+  completion['word'] = word
+  completion['abbr'] = abbr
+  completion['menu'] = menu
+  completion['info'] = info
   completion['args_pos'] = args_pos
   completion['dup'] = 1
 
@@ -427,8 +476,14 @@ def WarmupCache():
                      params, timer)
   t.start()
 
+def formatResultsPlain(results):
+    return map(formatResultPlain, results)
 
-def getCurrentCompletions(base):
+def formatResultsSnippets(results, formatSnippet, trailingPlaceholder):
+    f = lambda x: formatResultSnippets(x, formatSnippet, trailingPlaceholder)
+    return map(f, results)
+
+def getCurrentCompletions(base, formatSnippet, trailingPlaceholder):
   global debug
   debug = int(vim.eval("g:clang_debug")) == 1
   sorting = vim.eval("g:clang_sort_algo")
@@ -472,7 +527,10 @@ def getCurrentCompletions(base):
 
   timer.registerEvent("Sort")
 
-  result = map(formatResult, results)
+  if formatSnippet:
+    result = formatResultsSnippets(results, formatSnippet, trailingPlaceholder)
+  else:
+    result = formatResultsPlain(results)
 
   timer.registerEvent("Format")
   return (str(result), timer)


### PR DESCRIPTION
Some more tuning of clang_complete. The main contribution here is the removal of snippet formatting overhead for 'clang_complete' snippets. This patchset improves overall completion time from 150 to 100 msec.
