### PR TITLE
Use the 'with' syntax with the libclangLock.

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -413,8 +413,8 @@ class CompleteThread(threading.Thread):
                                     self.timer)
         else:
           self.result = getCurrentCompletionResults(self.line, self.column,
-                                                  self.args, self.currentFile,
-                                                  self.fileName, self.timer)
+                                                    self.args, self.currentFile,
+                                                    self.fileName, self.timer)
 
 def WarmupCache():
   params = getCompileParams(vim.current.buffer.name)


### PR DESCRIPTION
This removes the .acquire() and .release(), and avoid potential lockups if the code wasn't guarded by try catch.
