### PR TITLE
Add new configuration option clang_library_file

### DIFF
--- a/doc/clang_complete.txt
+++ b/doc/clang_complete.txt
@@ -214,6 +214,10 @@ Default: 0
 If libclang.[dll/so/dylib] is not in your library search path, set this to the
 absolute path where libclang is available.
 Default: ""
+                                        *clang_complete-library_file*
+                                        *g:clang_library_file*
+If libclang.[dll/so/dylib] has a special name, use this option.
+Default: ""
 
 					*clang_complete-sort_algo*
 					*g:clang_sort_algo*

--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -81,6 +81,10 @@ function! s:ClangCompleteInit()
     let g:clang_library_path = ''
   endif
 
+  if !exists('g:clang_library_file')
+    let g:clang_library_file = ''
+  endif
+
   if !exists('g:clang_complete_macros')
     let g:clang_complete_macros = 0
   endif
@@ -272,7 +276,7 @@ function! s:initClangCompletePython(user_requested)
 
     exe 'python sys.path = ["' . s:plugin_path . '"] + sys.path'
     exe 'pyfile ' . s:plugin_path . '/libclang.py'
-    py vim.command('let l:res = ' + str(initClangComplete(vim.eval('g:clang_complete_lib_flags'), vim.eval('g:clang_compilation_database'), vim.eval('g:clang_library_path'), vim.eval('a:user_requested'))))
+    py vim.command('let l:res = ' + str(initClangComplete(vim.eval('g:clang_complete_lib_flags'), vim.eval('g:clang_compilation_database'), vim.eval('g:clang_library_path'), vim.eval('g:clang_library_file'), vim.eval('a:user_requested'))))
     if l:res == 0
       return 0
     endif

--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -36,7 +36,7 @@ def getBuiltinHeaderPath(library_path):
   return None
 
 def initClangComplete(clang_complete_flags, clang_compilation_database, \
-                      library_path, user_requested):
+                      library_path, library_file, user_requested):
   global index
 
   debug = int(vim.eval("g:clang_debug")) == 1
@@ -44,6 +44,8 @@ def initClangComplete(clang_complete_flags, clang_compilation_database, \
 
   if library_path != "":
     Config.set_library_path(library_path)
+  if library_file != "":
+    Config.set_library_file(library_file)
 
   Config.set_compatibility_check(False)
 


### PR DESCRIPTION
This option makes it possible to specify a different library name.
Ubuntu 12.10, for instance, only installs /usr/lib/libclang.so.1
without an .so link, rendering clang_complete unusable - this option
fixes this problem if the user sets

let g:clang_library_file = "libclang.so.1"

in her .vimrc.