### PR TITLE
Kill the warmupthread on quit.

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -276,6 +276,7 @@ function! s:initClangCompletePython(user_requested)
     if l:res == 0
       return 0
     endif
+    au VimLeavePre * python FinishClangComplete()
     let s:libclang_loaded = 1
   endif
   python WarmupCache()

--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -1,4 +1,5 @@
 from clang.cindex import *
+from ctypes import *
 import vim
 import time
 import threading
@@ -390,6 +391,8 @@ def formatResult(result):
 
   return completion
 
+def finishThread(tid):
+  pythonapi.PyThreadState_SetAsyncExc(c_long(tid), py_object(Exception))
 
 class CompleteThread(threading.Thread):
   def __init__(self, line, column, currentFile, fileName, params, timer):
@@ -403,6 +406,12 @@ class CompleteThread(threading.Thread):
     self.cwd = params['cwd']
     self.timer = timer
 
+  def get_tid(self):
+    return self.ident
+
+  def finish(self):
+    finishThread(self.get_tid())
+
   def run(self):
     with workingDir(self.cwd):
       with libclangLock:
@@ -414,19 +423,29 @@ class CompleteThread(threading.Thread):
           # not locked The user does not see any delay, as we just pause
           # a background thread.
           time.sleep(0.1)
-          getCurrentTranslationUnit(self.args, self.currentFile, self.fileName,
-                                    self.timer)
+          try:
+            getCurrentTranslationUnit(self.args, self.currentFile, self.fileName,
+                                      self.timer)
+          except:
+            pass
         else:
           self.result = getCurrentCompletionResults(self.line, self.column,
                                                     self.args, self.currentFile,
                                                     self.fileName, self.timer)
 
+def FinishClangComplete():
+  while warmupthread.isAlive():
+    warmupthread.finish()
+    time.sleep(0.1)
+
 def WarmupCache():
+  global warmupthread
   params = getCompileParams(vim.current.buffer.name)
   timer = CodeCompleteTimer(0, "", -1, -1, params)
-  t = CompleteThread(-1, -1, getCurrentFile(), vim.current.buffer.name,
-                     params, timer)
-  t.start()
+  warmupthread = CompleteThread(-1, -1, getCurrentFile(),
+                                vim.current.buffer.name,
+                                params, timer)
+  warmupthread.start()
 
 
 def getCurrentCompletions(base):


### PR DESCRIPTION
This is fully based on the code of http://stackoverflow.com/questions/323972/is-there-any-way-to-kill-a-thread-in-python.

It works for me, going from a 5s shutdown to an instant one for example/boost.cpp.

It should fix #216.
