### PR TITLE
Launch one thread per file.

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -612,9 +612,8 @@ function! ClangComplete(findstart, base)
 
     if g:clang_use_library == 1
       python thread = getThread(vim.current.buffer.name)
-      let l:str = 'tryComplete(thread,' . b:col . ', str(' . a:base . '))'
-      let l:shouldRetry = pyeval('tryComplete(thread,' . b:col . ', "' . a:base . '")')
-      if l:shouldRetry
+      python vim.command('let l:shouldRetry = ' + str(tryComplete(thread, vim.eval('b:col'), vim.eval("a:base"))))
+      if l:shouldRetry == 1
         return []
       endif
       

--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -512,11 +512,12 @@ def WarmupCache():
 
 def tryComplete(t, column, base):
   state = t.getCompletionState()
+  column = int(column)
   if state == CompleteThread.STATE_FINISHED and column == t.column:
-    return False
+    return 0
 
   if state == CompleteThread.STATE_RUNNING:
-    return True
+    return 1
 
   if not t.is_alive():
     t.start()
@@ -531,7 +532,7 @@ def tryComplete(t, column, base):
   t.timer.start(vim.current.buffer.name, line, column, t.args, t.cwd)
   t.event.set()
 
-  return True
+  return 1
 
 def getCurrentCompletions(t):
   timer = t.timer


### PR DESCRIPTION
This code is not intended to be pushed as-it, my plan is to move nearly all the code inside the thread, and to avoid freezing the UI by returning as soon as possible to vim. Combined with fast regular polling, that will allow us to continue a completion even when the user is typing!

Fix issue #267, and when everything is in place, will also fix #245.
