### PR TITLE
Speed up "Load into vimscript".

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -605,7 +605,7 @@ function! ClangComplete(findstart, base)
 
     if g:clang_use_library == 1
       python completions, timer = getCurrentCompletions(vim.eval('a:base'))
-      python vim.command('let l:res = ' + completions)
+      let l:res = pyeval('completions')
       python timer.registerEvent("Load into vimscript")
     else
       let l:res = s:ClangCompleteBinary(a:base)

--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -457,13 +457,13 @@ def getCurrentCompletions(base):
     t.join(0.01)
     cancel = int(vim.eval('complete_check()'))
     if cancel != 0:
-      return (str([]), timer)
+      return ([], timer)
 
   cr = t.result
   if cr is None:
     print "Cannot parse this source file. The following arguments " \
         + "are used for clang: " + " ".join(params['args'])
-    return (str([]), timer)
+    return ([], timer)
 
   results = cr.results
 
@@ -486,7 +486,7 @@ def getCurrentCompletions(base):
   result = map(formatResult, results)
 
   timer.registerEvent("Format")
-  return (str(result), timer)
+  return (result, timer)
 
 def getAbbr(strings):
   for chunks in strings:


### PR DESCRIPTION
From 0.012s to 0.004s.

I'm using pyeval() in vim to avoid all the str() call in python. That way, no conversion is done. However, this requires an up to date vim, as noted in #270.
