### PR TITLE
Ensure to not expose the last_query cache

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -296,7 +296,12 @@ def getCompilationDBParams(fileName):
           continue
         args.append(arg)
       getCompilationDBParams.last_query = { 'args': args, 'cwd': cwd }
-  return getCompilationDBParams.last_query
+
+  # Do not directly return last_query, but make sure we return a deep copy.
+  # Otherwise users of that result may accidently change it and store invalid
+  # values in our cache.
+  query = getCompilationDBParams.last_query
+  return { 'args': list(query['args']), 'cwd': query['cwd']}
 
 getCompilationDBParams.last_query = { 'args': [], 'cwd': None }
 


### PR DESCRIPTION
Ensure we do not give out a reference to the internal argument cache of
the compilation database. Instead explicitly copy the internal cache.
The problem with just giving out a reference is that later passes may
modify the argument list. This does not only add unrelated content to
the internal cache, but it also may lead to random crashes in case we
use the argument list from different threads.
