### PR TITLE
Add options to control "jump to declaration" key mappings

### DIFF
--- a/doc/clang_complete.txt
+++ b/doc/clang_complete.txt
@@ -1,4 +1,4 @@
-*clang_complete.txt*	For Vim version 7.3.  Last change: 2013 Mar 3
+*clang_complete.txt*	For Vim version 7.3.  Last change: 2013 Mar 23
 
 
 		  clang_complete plugin documentation
@@ -232,6 +232,18 @@ Default: 0
 					*g:clang_complete_patterns*
 If clang should complete code patterns, i.e loop constructs etc.
 Defaut: 0
+
+					*clang_complete-jumpto_declaration_key*
+					*g:clang_jumpto_declaration_key*
+Set the key used to jump to declaration.
+Defaut: "<C-]>"
+
+					*clang_complete-jumpto_back_key*
+					*g:clang_jumpto_back_key*
+Set the key used to jump back.
+Note: Effectively this will be remapped to <C-O>. The default value is chosen
+to be coherent with ctags implementation.
+Defaut: "<C-T>"
 
 ==============================================================================
 6. Known issues					*clang_complete-issues*

--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -103,6 +103,14 @@ function! s:ClangCompleteInit()
     let g:clang_auto_user_options = 'path, .clang_complete'
   endif
 
+  if !exists('g:clang_jumpto_declaration_key')
+    let g:clang_jumpto_declaration_key = '<C-]>'
+  endif
+
+  if !exists('g:clang_jumpto_back_key')
+    let g:clang_jumpto_back_key = '<C-T>'
+  endif
+
   call LoadUserOptions()
 
   let b:my_changedtick = b:changedtick
@@ -141,8 +149,8 @@ function! s:ClangCompleteInit()
   inoremap <expr> <buffer> > <SID>CompleteArrow()
   inoremap <expr> <buffer> : <SID>CompleteColon()
   inoremap <expr> <buffer> <CR> <SID>HandlePossibleSelectionEnter()
-  nnoremap <buffer> <silent> <C-]> :call <SID>GotoDeclaration()<CR><Esc>
-  nnoremap <buffer> <silent> <C-T> <C-O>
+  execute "nnoremap <buffer> <silent> " . g:clang_jumpto_declaration_key . " :call <SID>GotoDeclaration()<CR><Esc>"
+  execute "nnoremap <buffer> <silent> " . g:clang_jumpto_back_key . " <C-O>"
 
   " Force menuone. Without it, when there's only one completion result,
   " it can be confusing (not completing and no popup)


### PR DESCRIPTION
g:clang_jumpto_declaration_key sets the key used to jump to declaration.
g:clang_jumpto_back_key sets the key used to jump back.
The default values are <C-]> and <C-T> respectively.
