### PR TITLE
Try to jump to definition before trying to go to the declaration.

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -534,9 +534,13 @@ def gotoDeclaration():
       f = File.from_name(tu, vim.current.buffer.name)
       loc = SourceLocation.from_position(tu, f, line, col + 1)
       cursor = Cursor.from_location(tu, loc)
-      if cursor.referenced is not None and loc != cursor.referenced.location:
-        loc = cursor.referenced.location
-        jumpToLocation(loc.file.name, loc.line, loc.column)
+      defs = [cursor.get_definition(), cursor.referenced]
+
+      for d in defs:
+        if d is not None and loc != d.location:
+          loc = d.location
+          jumpToLocation(loc.file.name, loc.line, loc.column)
+          break
 
   timer.finish()
 


### PR DESCRIPTION
Consider the following exemple:

``` c
static void a(int b);
int main(void)
{
    a(42);
}
static void a (int b) { }
```

Previously we would jump to the first line, while we're now jumping to the last.
