### PR TITLE
Only map <CR> when needed

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -148,7 +148,6 @@ function! s:ClangCompleteInit()
   inoremap <expr> <buffer> . <SID>CompleteDot()
   inoremap <expr> <buffer> > <SID>CompleteArrow()
   inoremap <expr> <buffer> : <SID>CompleteColon()
-  inoremap <expr> <buffer> <CR> <SID>HandlePossibleSelectionEnter()
   execute "nnoremap <buffer> <silent> " . g:clang_jumpto_declaration_key . " :call <SID>GotoDeclaration()<CR><Esc>"
   execute "nnoremap <buffer> <silent> " . g:clang_jumpto_back_key . " <C-O>"
 
@@ -365,6 +364,7 @@ function! ClangComplete(findstart, base)
     python timer.registerEvent("Load into vimscript")
 
     inoremap <expr> <buffer> <C-Y> <SID>HandlePossibleSelectionCtrlY()
+    inoremap <expr> <buffer> <CR> <SID>HandlePossibleSelectionEnter()
     augroup ClangComplete
       au CursorMovedI <buffer> call <SID>TriggerSnippet()
     augroup end
@@ -402,6 +402,7 @@ function! s:TriggerSnippet()
 
   " Stop monitoring as we'll trigger a snippet
   silent! iunmap <buffer> <C-Y>
+  silent! iunmap <buffer> <CR>
   augroup ClangComplete
     au! CursorMovedI <buffer>
   augroup end


### PR DESCRIPTION
Hi there!
This is a small patch to do the mapping of <CR> like it is done with <C-Y>. At least I don't see a reason not to, and it helps prevent conflicts with other plugins that also like to map <CR> in insert mode.
