### PR TITLE
 Fixup jumpToLocation loc.file is NoneType

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -539,8 +539,9 @@ def gotoDeclaration():
       for d in defs:
         if d is not None and loc != d.location:
           loc = d.location
-          jumpToLocation(loc.file.name, loc.line, loc.column)
-          break
+          if loc.file is not None:
+            jumpToLocation(loc.file.name, loc.line, loc.column)
+            break
 
   timer.finish()
 


### PR DESCRIPTION
Signed-off-by: visitor83 wolflouiswang@gmail.com
Error message as follows, then find out the libclang.py gotoDeclaration have some error

``` python
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/root/.vim/plugin/libclang.py", line 547, in gotoDeclaration
    jumpToLocation(loc.file.name, loc.line, loc.column)
AttributeError: 'NoneType' object has no attribute 'name'
```
