### PR TITLE
Update quickfix window when swtiching buffers.

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -8,6 +8,7 @@
 "
 
 au FileType c,cpp,objc,objcpp call <SID>ClangCompleteInit()
+au BufEnter * call<SID>ClangCompleteBufEnter()
 
 let b:clang_parameters = ''
 let b:clang_user_options = ''
@@ -16,6 +17,13 @@ let b:my_changedtick = 0
 " Store plugin path, as this is available only when sourcing the file,
 " not during a function call.
 let s:plugin_path = escape(expand('<sfile>:p:h'), '\')
+
+function! s:ClangCompleteBufEnter()
+  if &filetype == 'c' || &filetype == 'cpp' || 
+        \ &filetype == 'objc' || &filetype == 'objcpp' 
+    call<SID>ClangQuickFix()
+  endif
+endfunction
 
 function! s:ClangCompleteInit()
   let l:bufname = bufname("%")


### PR DESCRIPTION
When switching between buffers, the quickfix window does not automatically update. This patch checks when a BufEnter event happens, and refreshes the quickfix window.
