### PR TITLE
Improvement to logging when loading libclang fails

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -57,7 +57,7 @@ def initClangComplete(clang_complete_flags, clang_compilation_database, \
 
   debug = int(vim.eval("g:clang_debug")) == 1
 
-  if library_path != "":
+  if library_path:
     Config.set_library_path(library_path)
 
   Config.set_compatibility_check(False)
@@ -65,11 +65,19 @@ def initClangComplete(clang_complete_flags, clang_compilation_database, \
   try:
     index = Index.create()
   except Exception, e:
-    print "Loading libclang failed, completion won't be available"
-    if library_path == "":
-      print "Consider setting g:clang_library_path"
+    if library_path:
+      suggestion = "Are you sure '%s' contains libclang?" % library_path
     else:
-      print "Are you sure '%s' contains libclang?" % library_path
+      suggestion = "Consider setting g:clang_library_path."
+
+    if debug:
+      exception_msg = str(e)
+    else:
+      exception_msg = ''
+
+    print '''Loading libclang failed, completion won't be available. %s
+    %s
+    ''' % (suggestion, exception_msg)
     return 0
 
   global builtinHeaderPath


### PR DESCRIPTION
## Problem

libclang fails to load on OS X Mavericks with XCode 5.0.1 and the existing logging proved insufficient to track this down.

See http://stackoverflow.com/a/20645984/78845 .
## Changes
- Improve logging when loading libclang fails
- Add exception to error message in debug mode.
- Add check for non-existent string
- Squash strings together, since Vim will print multi-line strings but
  only displays the first string if multiple strings are emitted, using:

```
VIM - Vi IMproved 7.4 (2013 Aug 10, compiled Oct 19 2013 20:22:55)
MacOS X (unix) version
Included patches: 1-52
Compiled by Homebrew
```
