### PR TITLE
Allow not mapping keys by default

### DIFF
--- a/doc/clang_complete.txt
+++ b/doc/clang_complete.txt
@@ -250,6 +250,12 @@ Note: Effectively this will be remapped to <C-O>. The default value is chosen
 to be coherent with ctags implementation.
 Defaut: "<C-T>"
 
+					*clang_complete-make_default_keymappings*
+					*g:clang_make_default_keymappings*
+If this option is set, the default keymappings will be set by clang_complete.
+Otherwise none are set and the user will have to provide those keymappings.
+Default: 1
+
 ==============================================================================
 6. Known issues					*clang_complete-issues*
 

--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -117,6 +117,10 @@ function! s:ClangCompleteInit()
     let g:clang_jumpto_back_key = '<C-T>'
   endif
 
+  if !exists('g:clang_make_default_keymappings')
+    let g:clang_make_default_keymappings = 1
+  endif
+
   call LoadUserOptions()
 
   let b:my_changedtick = b:changedtick
@@ -150,12 +154,14 @@ function! s:ClangCompleteInit()
 
   python snippetsInit()
 
-  inoremap <expr> <buffer> <C-X><C-U> <SID>LaunchCompletion()
-  inoremap <expr> <buffer> . <SID>CompleteDot()
-  inoremap <expr> <buffer> > <SID>CompleteArrow()
-  inoremap <expr> <buffer> : <SID>CompleteColon()
-  execute "nnoremap <buffer> <silent> " . g:clang_jumpto_declaration_key . " :call <SID>GotoDeclaration()<CR><Esc>"
-  execute "nnoremap <buffer> <silent> " . g:clang_jumpto_back_key . " <C-O>"
+  if g:clang_make_default_keymappings == 1
+    inoremap <expr> <buffer> <C-X><C-U> <SID>LaunchCompletion()
+    inoremap <expr> <buffer> . <SID>CompleteDot()
+    inoremap <expr> <buffer> > <SID>CompleteArrow()
+    inoremap <expr> <buffer> : <SID>CompleteColon()
+    execute "nnoremap <buffer> <silent> " . g:clang_jumpto_declaration_key . " :call <SID>GotoDeclaration()<CR><Esc>"
+    execute "nnoremap <buffer> <silent> " . g:clang_jumpto_back_key . " <C-O>"
+  endif
 
   " Force menuone. Without it, when there's only one completion result,
   " it can be confusing (not completing and no popup)
@@ -369,8 +375,10 @@ function! ClangComplete(findstart, base)
     python vim.command('let l:res = ' + completions)
     python timer.registerEvent("Load into vimscript")
 
-    inoremap <expr> <buffer> <C-Y> <SID>HandlePossibleSelectionCtrlY()
-    inoremap <expr> <buffer> <CR> <SID>HandlePossibleSelectionEnter()
+    if g:clang_make_default_keymappings == 1
+      inoremap <expr> <buffer> <C-Y> <SID>HandlePossibleSelectionCtrlY()
+      inoremap <expr> <buffer> <CR> <SID>HandlePossibleSelectionEnter()
+    endif
     augroup ClangComplete
       au CursorMovedI <buffer> call <SID>TriggerSnippet()
     augroup end


### PR DESCRIPTION
I've been using this change for a while, and is time to propose upstreaming it.

It just adds a check on a variable to skip mapping stuff, since some people like it this way (e.g. me, since neocomplete already shows the menu). I set up the variable to 1 by default, since that doesn't break current users's setup, but I would set it to 0, so that would make future users that don't like their mappings to be touched less angry. :smile: 

Greetings.
