### PR TITLE
Activate clang_complete for C file sub-types

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -8,6 +8,7 @@
 "
 
 au FileType c,cpp,objc,objcpp call <SID>ClangCompleteInit()
+au FileType c.*,cpp.*,objc.*,objcpp.* call <SID>ClangCompleteInit()
 
 let b:clang_parameters = ''
 let b:clang_user_options = ''


### PR DESCRIPTION
Since I often write documentation with Doxygen, I automatically set doxygen file sub-type for C files. As a result, vim doesn't activate clang_complete.
This patch fixes problem for doxygen and all others sub-types.
