### PR TITLE
Split clang option arguments using POSIX standard.

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -190,8 +190,10 @@ def getCurrentTranslationUnit(args, currentFile, fileName, timer,
 
 def splitOptions(options):
   # Use python's shell command lexer to correctly split the list of options in
-  # accordance with the POSIX standard.
-  return shlex.split(options)
+  # accordance with the POSIX standard if running a Unix system, or split
+  # according to Windows shell rules
+  posixMode = os.name == "posix"
+  return shlex.split(options, posix=posixMode)
 
 def getQuickFix(diagnostic):
   # Some diagnostics have no file, e.g. "too many errors emitted, stopping now"


### PR DESCRIPTION
Uses Python standard library's `shlex` class to provide
accurate option parsing. It also prevents options quoted using
single quotes from being mishandled. i.e. The quotes are stripped
as expected.

Escaping using the escape character `\` is not supported at the
moment due to the clang_complete.vim converting all backslashes to
forward slashes (which is incorrect behaviour I might add).
However this is consistent with the current behaviour regardless.
