### PR TITLE
Prevent vim from hanging on exit

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -295,6 +295,8 @@ function! s:initClangCompletePython()
       return 0
     endif
     let s:libclang_loaded = 1
+
+    au VimLeavePre * python ForceExit()
   endif
   python WarmupCache()
   return 1

--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -443,6 +443,18 @@ def WarmupCache():
                      params, timer)
   t.start()
 
+def ForceExit():
+  # Close the current buffer to not leave any backup files.
+  vim.command("bd!")
+
+  # Now just kill vim. We do not really have another way to control the clang
+  # threads. Without killing vim, we would hang until all clang processes
+  # return. As we already closed the current buffer, we do not risk to loose
+  # a lot. The only remaining issue is that vim prints the 'Killed' text on
+  # exit.
+  import os
+  import signal
+  os.kill(os.getpid(), signal.SIGKILL)
 
 def getCurrentCompletions(base):
   global debug


### PR DESCRIPTION
Until now, vim would hang on exit to wait for the warmup thread or other
completion threads to finish. This can cause an annoying 1-5 seconds
delay when exiting vim. We address this issue by manually closing the
current buffer and then directly killing vim. This is a little hackish,
but we unfortunately do not have any control over running clang threads.
As we close all buffers in advance, the risk that we loose something by
killing vim is minimal. The only remaining annoyance is that vim prints
'Killed' on exit. I doubt there is a lot we can do about this.
