### PR TITLE
Improve relative>absolute filename option handling

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -210,29 +210,90 @@ function! LoadUserOptions()
   endfor
 endfunction
 
+" Used to tell if a flag needs a space between the flag and file
+let s:flagInfo = {
+\   '-I': {
+\     'pattern': '-I\s*',
+\     'output': '-I'
+\   },
+\   '-F': {
+\     'pattern': '-F\s*',
+\     'output': '-F'
+\   },
+\   '-iquote': {
+\     'pattern': '-iquote\s*',
+\     'output': '-iquote'
+\   },
+\   '-include': {
+\     'pattern': '-include\s\+',
+\     'output': '-include '
+\   }
+\ }
+
+let s:flagPatterns = []
+for s:flag in values(s:flagInfo)
+  let s:flagPatterns = add(s:flagPatterns, s:flag.pattern)
+endfor
+let s:flagPattern = '\%(' . join(s:flagPatterns, '\|') . '\)'
+
+
+function! s:processFilename(filename, root)
+  " Handle Unix absolute path
+  if matchstr(a:filename, '\C^[''"\\]\=/') != ''
+    let l:filename = a:filename
+  " Handle Windows absolute path
+  elseif s:isWindows() 
+       \ && matchstr(a:filename, '\C^"\=[a-zA-Z]:[/\\]') != ''
+    let l:filename = a:filename
+  " Convert relative path to absolute path
+  else
+    " If a windows file, the filename may need to be quoted.
+    if s:isWindows()
+      if matchstr(a:filename, '\C^".*"\s*$') == ''
+        let l:filename = substitute(a:filename, '\C^\(.\{-}\)\s*$'
+                                            \ , '"' . a:root . '\1"', 'g')
+      else
+        " Strip first double-quote and prepend the root.
+        let l:filename = substitute(a:filename, '\C^"\(.\{-}\)\s*$'
+                                            \ , '"' . a:root . '\1"', 'g')
+      endif
+    else
+      " For Unix, assume the filename is already escaped/quoted correctly
+      let l:filename = shellescape(a:root) . a:filename
+    endif
+  endif
+  
+  return l:filename
+endfunction
+
 function! s:parseConfig()
   let l:local_conf = findfile('.clang_complete', getcwd() . ',.;')
   if l:local_conf == '' || !filereadable(l:local_conf)
     return
   endif
 
-  let l:root = substitute(fnamemodify(l:local_conf, ':p:h'), '\', '/', 'g')
+  let l:sep = '/'
+  if s:isWindows()
+    let l:sep = '\'
+  endif
+
+  let l:root = fnamemodify(l:local_conf, ':p:h') . l:sep
 
   let l:opts = readfile(l:local_conf)
   for l:opt in l:opts
-    " Use forward slashes only
-    let l:opt = substitute(l:opt, '\', '/', 'g')
-    " Handling of absolute path
-    if matchstr(l:opt, '\C-I\s*/') != ''
-      let l:opt = substitute(l:opt, '\C-I\s*\(/\%(\w\|\\\s\)*\)',
-            \ '-I' . '\1', 'g')
-    elseif s:isWindows() && matchstr(l:opt, '\C-I\s*[a-zA-Z]:/') != ''
-      let l:opt = substitute(l:opt, '\C-I\s*\([a-zA-Z:]/\%(\w\|\\\s\)*\)',
-            \ '-I' . '\1', 'g')
-    else
-      let l:opt = substitute(l:opt, '\C-I\s*\(\%(\w\|\.\|/\|\\\s\)*\)',
-            \ '-I' . l:root . '/\1', 'g')
+    " Ensure passed filenames are absolute. Only performed on flags which
+    " require a filename/directory as an argument, as specified in s:flagInfo
+    if matchstr(l:opt, '\C^\s*' . s:flagPattern . '\s*') != ''
+      let l:flag = substitute(l:opt, '\C^\s*\(' . s:flagPattern . '\).*'
+                            \ , '\1', 'g')
+      let l:flag = substitute(l:flag, '^\(.\{-}\)\s*$', '\1', 'g')
+      let l:filename = substitute(l:opt,
+                                \ '\C^\s*' . s:flagPattern . '\(.\{-}\)\s*$',
+                                \ '\1', 'g')
+      let l:filename = s:processFilename(l:filename, l:root)
+      let l:opt = s:flagInfo[l:flag].output . l:filename
     endif
+
     let b:clang_user_options .= ' ' . l:opt
   endfor
 endfunction


### PR DESCRIPTION
Relative -> absolute filename handling now occurs for the following flags:
 `-I`
 `-F`
 `-iquote`
 `-include`

Rather than just `-I`.

Backslashes are now no longer erroneously removed, and can be used as an
escape character on posix systems.

Relative → absolute filename handling should be more robust in general.
