### PR TITLE
Use SIGTERM rather than SIGKILL to force quit

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -454,7 +454,7 @@ def ForceExit():
   # exit.
   import os
   import signal
-  os.kill(os.getpid(), signal.SIGKILL)
+  os.kill(os.getpid(), signal.SIGTERM)
 
 def getCurrentCompletions(base):
   global debug


### PR DESCRIPTION
See #389 for related discussion.

@tobig, could you test and merge this pull request if it works for you the same way as with `SIGKILL`? I'm quite confident that one should almost never use `SIGKILL`, nevertheless I'd like to be sure that your code in #389 works with this change.
