### PR TITLE
Simple hack to allow tab in insert mode when completing function arguments

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -163,6 +163,7 @@ function! s:ClangCompleteInit()
     inoremap <expr> <buffer> . <SID>CompleteDot()
     inoremap <expr> <buffer> > <SID>CompleteArrow()
     inoremap <expr> <buffer> : <SID>CompleteColon()
+    inoremap <expr> <buffer> <tab> <SID>updateSnipsInsert()
     execute "nnoremap <buffer> <silent> " . g:clang_jumpto_declaration_key . " :call <SID>GotoDeclaration(0)<CR><Esc>"
     execute "nnoremap <buffer> <silent> " . g:clang_jumpto_declaration_in_preview_key . " :call <SID>GotoDeclaration(1)<CR><Esc>"
     execute "nnoremap <buffer> <silent> " . g:clang_jumpto_back_key . " <C-O>"
@@ -484,6 +485,26 @@ function! s:CompleteColon()
     return ':'
   endif
   return ':' . s:LaunchCompletion()
+endfunction
+
+function! s:updateSnipsInsert()
+python << EOF
+import vim
+line = vim.current.line
+row, col = vim.current.window.cursor
+
+r = re.compile('\$`[^`]*`')
+result = r.search(line)
+
+if result is None:
+  if col < len(line) and ( line[col] == ')' or line[col] == '>'):
+    vim.command('return "\<esc>A"')
+  else:
+    vim.command('return "\<c-i>"')
+else:
+  vim.command('call feedkeys("\<esc>\<c-i>")')
+  vim.command('return ""')
+EOF
 endfunction
 
 function! s:GotoDeclaration(preview)


### PR DESCRIPTION
Although there has been a discussion and the issue was basically closed as WONTFIX I wanted to propose my simple hack for inclusion. It allows cycling through completable function/template arguments via <tab> in insert mode. When there is nothing to complete in the current line, <tab> works as usual. When the cursor is on a ')' or '>', i.e. after the last completion, an 'A' is inserted to go to the end of the line.
