### PR TITLE
Makefile fix: SHELL should be set to /usr/bin/env bash not $(/usr/bin/en...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL	:= $(/usr/bin/env bash)
+SHELL	:= /usr/bin/env bash
 FILES	:= $(shell git ls-files autoload bin doc plugin)
 
 all: clang_complete.vmb


### PR DESCRIPTION
Any make command fails due to this modification which has been made just a couple of days ago.
