### PR TITLE
set mark when jumping to location in current file

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -503,7 +503,7 @@ def jumpToLocation(filename, line, column, preview):
   elif filename != vim.current.buffer.name:
     command = "edit %s" % filenameEscaped
   else:
-    command = "normal m"
+    command = "normal m'"
   try:
     vim.command(command)
   except:


### PR DESCRIPTION
The normal mode command m' was there before but got broken by commit 6f491682: m without the single quote is not a normal mode command. When changing files, the jump list is already updated.
