### PR TITLE
Allow specifying clang's lib full path, not just its dir

### DIFF
--- a/doc/clang_complete.txt
+++ b/doc/clang_complete.txt
@@ -218,8 +218,9 @@ Default: 1
 
        				       	*clang_complete-library_path*
        				       	*g:clang_library_path*
-If libclang.[dll/so/dylib] is not in your library search path, set this to the
-absolute path where libclang is available.
+If libclang is not in your library search path, set this to the absolute path
+where libclang is available. This should either be a directory containing a
+file named libclang.[dll/so/dylib] or the clang shared library file itself.
 Default: ""
 
 					*clang_complete-sort_algo*

--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -59,7 +59,10 @@ def initClangComplete(clang_complete_flags, clang_compilation_database, \
   debug = int(vim.eval("g:clang_debug")) == 1
 
   if library_path:
-    Config.set_library_path(library_path)
+    if os.path.isdir(library_path):
+      Config.set_library_path(library_path)
+    else:
+      Config.set_library_file(library_path)
 
   Config.set_compatibility_check(False)
 


### PR DESCRIPTION
Some systems don't install a libclang.so symlink but instead leave
filenames like [libclang.so.1](http://packages.ubuntu.com/precise-updates/amd64/libclang1-3.4/filelist). So the ability to specify the
directory containing the clang shared library isn't always enough. This
change allows specifying the full library path while maintaining the
ability to specify just its containing directory.

As an example of the problem,
[libclang1-3.4:amd64=1:3.4-1ubuntu3~precise1](http://packages.ubuntu.com/precise-updates/amd64/libclang1-3.4/filelist) on Ubuntu has both these
full paths available for clang's shared library (one's a symlink),
neither of which is named exactly 'libclang.so':
- /usr/lib/llvm-3.4/lib/libclang.so.1
- /usr/lib/x86_64-linux-gnu/libclang-3.4.so.1

As an example, this is what I'm using in my .vimrc:

``` vim
let g:clang_library_path = glob("/usr/lib/*/libclang.so*")
```
