### PR TITLE
Add -ansi and -pedantic to cc_args.py

### DIFF
--- a/bin/cc_args.py
+++ b/bin/cc_args.py
@@ -56,6 +56,10 @@ def parseArguments(arguments):
       nextIsIncludeFile = True
     elif arg.startswith('-std='):
       options.append(arg)
+    elif arg == '-ansi':
+      options.append(arg)
+    elif arg.startswith('-pedantic'):
+      options.append(arg)
     elif arg.startswith('-W'):
       options.append(arg)
 


### PR DESCRIPTION
-ansi is equivalent to -std=c89, and -pedantic and -pedantic-erros cause non-compliant code to be rejected, which may affect code completion.