### PR TITLE
Optional arguments are supported in completion.

### DIFF
--- a/doc/clang_complete.txt
+++ b/doc/clang_complete.txt
@@ -148,6 +148,15 @@ for details): >
 
 Default: 1 (0 if conceal not available)
 
+       				       	*clang_complete-optional_args_in_snippets*
+       				       	*g:clang_complete_optional_args_in_snippets*
+If equal to 1, it will add optional arguments to the function call snippet.
+Snippet replaceable object will not be only the argument, but the preceding
+comma will be included as well, so you can press backspace to delete the
+optional argument, while the replaceable is selected.
+Example: foo($`T param1`, $`T param2`$`, T optional_param`)
+Default: 0
+
        				       	*clang_complete-clang_trailing_placeholder*
        				       	*g:clang_trailing_placeholder*
 Note: This option is specific to clang_complete snippets engine.

--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -80,6 +80,10 @@ function! s:ClangCompleteInit()
     echoe 'clang_complete: conceal feature not available but requested'
   endif
 
+  if !exists('g:clang_complete_optional_args_in_snippets')
+    let g:clang_complete_optional_args_in_snippets = 0
+  endif
+
   if !exists('g:clang_trailing_placeholder')
     let g:clang_trailing_placeholder = 0
   endif

--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -365,6 +365,20 @@ def formatResult(result):
   abbr = ""
   word = ""
   info = ""
+  place_markers_for_optional_args = int(vim.eval("g:clang_complete_optional_args_in_snippets")) == 1
+
+  def roll_out_optional(chunks):
+    result = []
+    word = ""
+    for chunk in chunks:
+      if chunk.isKindInformative() or chunk.isKindResultType() or chunk.isKindTypedText():
+        continue
+
+      word += chunk.spelling
+      if chunk.isKindOptional():
+        result += roll_out_optional(chunk.string)
+
+    return [word] + result
 
   for chunk in result.string:
 
@@ -379,6 +393,12 @@ def formatResult(result):
 
     if chunk.isKindTypedText():
       abbr = chunk_spelling
+
+    if chunk.isKindOptional():
+      for optional_arg in roll_out_optional(chunk.string):
+        if place_markers_for_optional_args:
+          word += snippetsFormatPlaceHolder(optional_arg)
+        info += optional_arg + "=?"
 
     if chunk.isKindPlaceHolder():
       word += snippetsFormatPlaceHolder(chunk_spelling)


### PR DESCRIPTION
Optional parameters were not present in completion menu.
This change adds them in this format: foo(int a, int b=?)
It would be great if it would be possible to print the exact value instead of '?', but this is better then nothing.
Snippet can also contain default argument if g:clang_complete_optional_args_in_snippets is set to 1.
