### PR TITLE
Add OmniCppComplete compatibility mode

### DIFF
--- a/doc/clang_complete.txt
+++ b/doc/clang_complete.txt
@@ -26,7 +26,11 @@ This plugin use clang for accurately completing C and C++ code.
 
 Note: This plugin is incompatible with omnicppcomplete due to the
 unconditionnaly set mapping done by omnicppcomplete. So don't forget to
-suppress it before using this plugin.
+suppress it before using this plugin. Also it's possible to keep
+omnicppcomplete plugin enabled by setting |g:clang_omnicppcomplete_compliance|.
+in this case it will be possible to use omnicppcomplete in parallel with
+clang_complete, though functionality of the latter will be reduced to
+<C-X><C-U> only.
 
 ==============================================================================
 2. Key bindings					*clang_complete-keybindings*
@@ -280,6 +284,13 @@ Defaut: "<C-T>"
 If this option is set, the default keymappings will be set by clang_complete.
 Otherwise none are set and the user will have to provide those keymappings.
 Default: 1
+
+					*clang_complete-omnicppcomplete_compliance*
+					*g:clang_omnicppcomplete_compliance*
+Omnicppcomplete compatibility mode. Keeps omni auto-completion in control of
+omnicppcomplete, disables clang's auto-completion (|g:clang_complete_auto|)
+and enables only <C-X><C-U> as main clang completion function.
+Defaut: 0
 
 ==============================================================================
 6. Known issues					*clang_complete-issues*

--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -136,6 +136,15 @@ function! s:ClangCompleteInit()
     let g:clang_restore_cr_imap = 'iunmap <buffer> <CR>'
   endif
 
+  if !exists('g:clang_omnicppcomplete_compliance')
+    let g:clang_omnicppcomplete_compliance = 0
+  endif
+
+  if g:clang_omnicppcomplete_compliance == 1
+    let g:clang_complete_auto = 0
+    let g:clang_make_default_keymappings = 0
+  endif
+
   call LoadUserOptions()
 
   let b:my_changedtick = b:changedtick
@@ -179,6 +188,10 @@ function! s:ClangCompleteInit()
     execute "nnoremap <buffer> <silent> " . g:clang_jumpto_back_key . " <C-O>"
   endif
 
+  if g:clang_omnicppcomplete_compliance == 1
+    inoremap <expr> <buffer> <C-X><C-U> <SID>LaunchCompletion()
+  endif
+
   " Force menuone. Without it, when there's only one completion result,
   " it can be confusing (not completing and no popup)
   if g:clang_auto_select != 2
@@ -198,7 +211,10 @@ function! s:ClangCompleteInit()
   endif
 
   setlocal completefunc=ClangComplete
-  setlocal omnifunc=ClangComplete
+  if g:clang_omnicppcomplete_compliance == 0
+    setlocal omnifunc=ClangComplete
+  endif
+
 endfunction
 
 function! LoadUserOptions()


### PR DESCRIPTION
Allow clang_complete to be used in parallel with OmniCppComplete, mostly
as an alternative manual-completion method.

In this mode all omni auto-completion is kept in control of
OmniCppComplete plugin, clang's auto-completion is disabled, keeping
only `<C-X><C-U>` as main clang completion function.

This mode is enabled by `g:clang_omnicppcomplete_compliance` configuration
option.