### PR TITLE
Find the correct clang library version in linux

### DIFF
--- a/plugin/clang/cindex.py
+++ b/plugin/clang/cindex.py
@@ -63,6 +63,7 @@ call is efficient.
 # o implement additional SourceLocation, SourceRange, and File methods.
 
 from ctypes import *
+from ctypes.util import find_library
 import collections
 
 import clang.enumerations
@@ -3147,7 +3148,7 @@ class Config:
         elif name == 'Windows':
             file = 'libclang.dll'
         else:
-            file = 'libclang.so'
+            file = find_library("clang") or 'libclang.so'
 
         if Config.library_path:
             file = Config.library_path + '/' + file


### PR DESCRIPTION
In linux the loading of the clang library might fail unless you specify ```let g:clang_library_path='/usr/lib/llvm-3.4/lib/libclang.so.1```. 

Using find_library() can help solving this problem by finding the correct file looking at different versions of the library in the path.