### PR TITLE
Changed snippets expand key mapping

### DIFF
--- a/plugin/snippets/clang_complete.py
+++ b/plugin/snippets/clang_complete.py
@@ -2,8 +2,8 @@ import re
 import vim
 
 def snippetsInit():
-  vim.command("noremap <silent> <buffer> <tab> :python updateSnips()<CR>")
-  vim.command("snoremap <silent> <buffer> <tab> <ESC>:python updateSnips()<CR>")
+  vim.command("inoremap <silent> <buffer> <C-e> <ESC>:python updateSnips()<CR>")
+  vim.command("snoremap <silent> <buffer> <C-e> <ESC>:python updateSnips()<CR>")
   if int(vim.eval("g:clang_conceal_snippets")) == 1:
     vim.command("syntax match placeHolder /\$`[^`]*`/ contains=placeHolderMark")
     vim.command("syntax match placeHolderMark contained /\$`/ conceal")


### PR DESCRIPTION
Changed snippets expand key mapping from <tab> to <C-e> because <tab> is used too common in other scenarios, like auto-completion, indent, candidates selection...

And hard coding mapping is not good...this can be a workaround.