### PR TITLE
Fix missing support for cpp sub-filetypes

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -154,7 +154,7 @@ function! s:ClangCompleteInit()
     let b:clang_parameters = '-x objective-c'
   endif
 
-  if &filetype == 'cpp' || &filetype == 'objcpp'
+  if &filetype == 'cpp' || &filetype == 'objcpp' || &filetype =~ 'cpp.*' || &filetype =~ 'objcpp.*'
     let b:clang_parameters .= '++'
   endif
 


### PR DESCRIPTION
When setting a subtype for the cpp filetype, e.g. cpp.doxygen to highlight
doxygen documentation, clang_complete did not recognize it as c++ anymore
and used the `-x c` flag for clang instead of `-x c++`. This lead to broken 
completions, e.g. for the STL.