### PR TITLE
Pass -fno-color-diagnostics to clang

### DIFF
--- a/plugin/clang/cindex.py
+++ b/plugin/clang/cindex.py
@@ -1991,6 +1991,8 @@ class TranslationUnit(ClangObject):
         if args is None:
             args = []
 
+        args.append('-fno-color-diagnostics')
+
         if unsaved_files is None:
             unsaved_files = []
 


### PR DESCRIPTION
Fixes #453, bug in clang itself is open for quite some
time now, so in the meantime adding workaround directly
into clang_complete seems like a reasonable workaround.