### PR TITLE
Fixed libclang not finding builtin includes

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -42,7 +42,7 @@ def getBuiltinHeaderPath(library_path):
     try:
       files = os.listdir(path)
       if len(files) >= 1:
-        files = sorted(files)
+        files = list(reversed(sorted(files)))
         subDir = files[-1]
       else:
         subDir = '.'


### PR DESCRIPTION
The original script considered that the list containing the subdirectories of the clang lib directory, when ordered, would have the entry corresponding to the current version of clang (which is the path it wants) in its first position, when it should actually be the last. Error would insue and the following would be output:

> WARNING: libclang can not find the builtin includes.
>                   This will cause slow code completion.
>                   Please report the problem.

In the presence of other subdirectories or binaries (which is the case when a static analyzer is also present), `subDir` would contain the wrong result. The solution to this, implemented in this patch, is to, after sorting, also reverse the ordering of `files`, before defining `subDir`.