### PR TITLE
Fix libclang.py builtin includes search (#238)

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -40,15 +40,10 @@ def getBuiltinHeaderPath(library_path):
 
   for path in knownPaths:
     try:
-      files = os.listdir(path)
-      if len(files) >= 1:
-        files = sorted(files)
-        subDir = files[-1]
-      else:
-        subDir = '.'
-      path = path + "/" + subDir + "/include/"
-      arg = "-I" + path
-      if canFindBuiltinHeaders(index, [arg]):
+      subDirs = [f for f in os.listdir(path) if os.path.isdir(path + "/" + f)]
+      subDirs = sorted(subDirs) or ['.']
+      path = path + "/" + subDirs[-1] + "/include"
+      if canFindBuiltinHeaders(index, ["-I" + path]):
         return path
     except:
       pass


### PR DESCRIPTION
The old code tried to find builtin includes from the lexicographically
last directory returned by os.listdir() for the hardcoded knownPaths.
However, the code did not check that the filename listed by os.listdir()
was indeed a directory and not a file. clang>=3.8.0 added c++-analyzer
and ccc-analyzer binaries under /usr/lib/clang, which broke the builtin
includes search. This commit adds the missing os.isdir() check.