### PR TITLE
Add "follow reference" to go to typedef

### DIFF
--- a/plugin/clang/cindex.py
+++ b/plugin/clang/cindex.py
@@ -1086,9 +1086,9 @@ class Cursor(Structure):
 
     def get_definition(self):
         """
-        If the cursor is a reference to a declaration or a declaration of
-        some entity, return a cursor that points to the definition of that
-        entity.
+        If the cursor is a declaration of some entity or a reference to a
+        declaration of some entity, return a cursor that points to the
+        definition of that entity.
         """
         # TODO: Should probably check that this is either a reference or
         # declaration prior to issuing the lookup.

--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -629,9 +629,10 @@ function! s:CompleteColon()
   return ':' . s:LaunchCompletion()
 endfunction
 
-function! s:GotoDeclaration(preview)
+function! s:GotoDeclaration(preview, type_declaration)
   try
-    execute s:py_cmd "gotoDeclaration(vim.eval('a:preview') == '1')"
+    execute s:py_cmd "gotoDeclaration(vim.eval('a:preview') == '1', "
+                                   \."vim.eval('a:type_declaration') == '1')"
   catch /^Vim\%((\a\+)\)\=:E37/
     echoe "The current file is not saved, and 'hidden' is not set."
           \ "Either save the file or add 'set hidden' in your vimrc."
@@ -645,13 +646,23 @@ function! g:ClangUpdateQuickFix()
   return ''
 endfunction
 
+function! g:ClangFollowReference()
+  call s:GotoDeclaration(0, 1)
+  return ''
+endfunction
+
+function! g:ClangFollowReferencePreview()
+  call s:GotoDeclaration(1, 1)
+  return ''
+endfunction
+
 function! g:ClangGotoDeclaration()
-  call s:GotoDeclaration(0)
+  call s:GotoDeclaration(0, 0)
   return ''
 endfunction
 
 function! g:ClangGotoDeclarationPreview()
-  call s:GotoDeclaration(1)
+  call s:GotoDeclaration(1, 0)
   return ''
 endfunction
 

--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -549,7 +549,7 @@ def jumpToLocation(filename, line, column, preview):
   if not preview:
     vim.current.window.cursor = (line, column - 1)
 
-def gotoDeclaration(preview=True):
+def gotoDeclaration(preview=True, type_declaration=False):
   global debug
   debug = int(vim.eval("g:clang_debug")) == 1
   params = getCompileParams(vim.current.buffer.name)
@@ -567,7 +567,10 @@ def gotoDeclaration(preview=True):
     f = File.from_name(tu, vim.current.buffer.name)
     loc = SourceLocation.from_position(tu, f, line, col + 1)
     cursor = Cursor.from_location(tu, loc)
-    defs = [cursor.get_definition(), cursor.referenced]
+    if type_declaration:
+      defs = [cursor.type.get_declaration() if cursor.type else None]
+    else:
+      defs = [cursor.get_definition(), cursor.referenced]
 
     for d in defs:
       if d is not None and loc != d.location:


### PR DESCRIPTION
Currently, `clang_complete` does not support following definitions very well in code like this:

```c++
template <typename T, typename A>
struct factory {
	A value;
	factory(A value) : value(value) {}
	T construct() { return T(value); }
};

struct Foo {
	Foo(int) {}
};

typedef factory<Foo, int> foo;

struct Bar {
	Bar(float) {}
};

typedef factory<Bar, float> bar;

int main() {
	auto x = foo(42).construct();
	auto y = bar(123.0).construct();
	return 0;
}
```

I want to go from `foo` in `main()` to the `typedef factory<Foo, int> foo;` line. However, `C-]` (or `g:ClangGotoDeclaration`) goes straight through the typedef to the definition of `factory::factory`, which is useless. After some print-debugging, it seems that in function [`gotoDeclaration`](https://github.com/Rip-Rip/clang_complete/blob/b1a507fbc27ef581c966b035f52eafae773a6f32/plugin/libclang.py#L552), neither `cursor.get_definition()` nor `cursor.referenced` returns a cursor to the typedef; both return cursors to the constructor. From my limited experimentation it seems to only occur when the typedef is for a templated type.

Fortunately, `cursor.type.get_declaration()` goes to the typedef. This patch adds support for going to that cursor and thus fixes the problem.

I've added `map \g :call g:ClangGotoDeclaration()<CR>` to my `vimrc`, and now I can go to the typedef using that binding.