### PR TITLE
Use json.dumps to stringify quickfix content, fixes #270

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -375,6 +375,7 @@ function! s:initClangCompletePython()
   " Only parse the python library once
   if !exists('s:libclang_loaded')
     execute s:py_cmd 'import sys'
+    execute s:py_cmd 'import json'
 
     execute s:py_cmd 'sys.path = ["' . s:plugin_path . '"] + sys.path'
     execute s:pyfile_cmd fnameescape(s:plugin_path) . '/libclang.py'
@@ -421,7 +422,7 @@ function! s:ClangQuickFix()
   syntax clear SpellBad
   syntax clear SpellLocal
 
-  execute s:py_cmd "vim.command('let l:list = ' + str(getCurrentQuickFixList()))"
+  execute s:py_cmd "vim.command('let l:list = ' + json.dumps(getCurrentQuickFixList()))"
   execute s:py_cmd 'highlightCurrentDiagnostics()'
 
   if g:clang_complete_copen == 1


### PR DESCRIPTION
When a string is not terminated, vim would throw an exception when updating quickfix.
This is because str would stringify using single quotes, which in vim are interpreted literally (vim will not interpret the escape sequences and will prematurely terminate a string).
Using json.dumps forces the use of double quoted strings, so vim can interpret them correctly