### PR TITLE
Only highlight diagnostics from the current file

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -248,6 +248,9 @@ def highlightRange(range, hlGroup):
   vim.command(command)
 
 def highlightDiagnostic(diagnostic):
+  if decode(diagnostic.location.file.name) != vim.eval('expand("%:p")'):
+    return
+
   if diagnostic.severity == diagnostic.Warning:
     hlGroup = 'SpellLocal'
   elif diagnostic.severity == diagnostic.Error:


### PR DESCRIPTION
When issues were detected in an included header file, they would get incorrectly highlighted by clang_complete in the file that included that header.