### PR TITLE
Allow to skip builtin headers

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -340,7 +340,7 @@ def getCompileParams(fileName):
   args += splitOptions(vim.eval("b:clang_user_options"))
   args += splitOptions(vim.eval("b:clang_parameters"))
 
-  if builtinHeaderPath:
+  if builtinHeaderPath and '-nobuiltininc' not in args:
     args.append("-I" + builtinHeaderPath)
 
   return { 'args' : args,


### PR DESCRIPTION
Yet another PR, this is useful when developing for embedded devices, like esp8266. Otherwise the builtin file will be included every time, even when you don't want to do this