### PR TITLE
Fix for errors that don't have filename attached

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -248,7 +248,8 @@ def highlightRange(range, hlGroup):
   vim.command(command)
 
 def highlightDiagnostic(diagnostic):
-  if decode(diagnostic.location.file.name) != vim.eval('expand("%:p")'):
+  if diagnostic.location.file is None or \
+     decode(diagnostic.location.file.name) != vim.eval('expand("%:p")'):
     return
 
   if diagnostic.severity == diagnostic.Warning:


### PR DESCRIPTION
Some errors, for example "too many errors emitted, stopping now" don't have file property set. Skip highlighting errors in this case, previously they weren't highlighted, because generated command matched line 0, column 0.