### PR TITLE
Add optional snippet placeholders at the end again

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -388,6 +388,8 @@ def formatResult(result):
   word = ""
   info = ""
   place_markers_for_optional_args = int(vim.eval("g:clang_complete_optional_args_in_snippets")) == 1
+  add_trailing_placeholders = int(vim.eval("g:clang_trailing_placeholder")) == 1
+  use_clang_complete_snippets = vim.eval("g:clang_snippets_engine") == "clang_complete"
 
   def roll_out_optional(chunks):
     result = []
@@ -433,6 +435,9 @@ def formatResult(result):
 
   if returnValue:
     menu = decode(returnValue.spelling) + " " + menu
+
+  if add_trailing_placeholders and use_clang_complete_snippets:
+    word += snippetsFormatPlaceHolder('')
 
   completion['word'] = snippetsAddSnippet(info, word, abbr)
   completion['abbr'] = abbr


### PR DESCRIPTION
Having the option clang_trailing_placeholder set to 1, there should be a
trailing placeholder at the end of every completion string, if the
snippets engine is clang_complete. This has previously been implemented
by 742694b, but apparently wasn't ported to the newer python
implementation of the snippet construction.