### PR TITLE
Improvements

### DIFF
--- a/doc/clang_complete.txt
+++ b/doc/clang_complete.txt
@@ -137,6 +137,12 @@ The snippets engine (clang_complete, ultisnips... see the snippets
 subdirectory).
 Default: "clang_complete"
 
+				       	*clang_complete-snippet_jump_map*
+				       	*g:clang_complete_snippet_jump_map*
+Key clang_complete snippet engine uses to jump between replaceables.
+If it is empty string, then nothing is mapped.
+Default: '<tab>'
+
        				       	*clang_complete-conceal_snippets*
        				       	*g:clang_conceal_snippets*
 Note: This option is specific to clang_complete snippets engine.
@@ -272,18 +278,21 @@ Default: 0
 					*g:clang_print_type_key*
 Set the key used to print the type of the identifier under cursor.
 If cursor is on an enum, then the value of that enum is also printed.
+If it is empty then no shortcut will be created to gather this info.
 Defaut: "zp"
 Note: You can call ClangPrintType() vim function to print this information.
 
 					*clang_complete-jumpto_declaration_key*
 					*g:clang_jumpto_declaration_key*
 Set the key used to jump to declaration.
+If it is empty then no shortcut will be created for this jump.
 Default: "<C-]>"
 Note: You could use the g:ClangGotoDeclaration() to do the same with a mapping.
 
 					*clang_complete-jumpto_declaration_in_preview_key*
 					*g:clang_jumpto_declaration_in_preview_key*
 Set the key used to jump to declaration in a preview window.
+If it is empty then no shortcut will be created for this jump.
 Default: "<C-W>]"
 Note: You could use the g:ClangGotoDeclarationPreview() to do the same with a mapping.
 
@@ -292,6 +301,7 @@ Note: You could use the g:ClangGotoDeclarationPreview() to do the same with a ma
 Set the key used to jump back.
 Note: Effectively this will be remapped to <C-O>. The default value is chosen
 to be coherent with ctags implementation.
+If it is empty then nothing will be remapped to <C-O>, you can use <C-O> as it is.
 Default: "<C-T>"
 
 					*clang_complete-make_default_keymappings*

--- a/doc/clang_complete.txt
+++ b/doc/clang_complete.txt
@@ -268,6 +268,12 @@ Default: 0
 If clang should complete code patterns, i.e loop constructs etc.
 Default: 0
 
+					*clang_complete-print_type_key*
+					*g:clang_print_type_key*
+Set the key used to print the type of the identifier under cursor.
+If cursor is on an enum, then the value of that enum is also printed.
+Defaut: "zp"
+
 					*clang_complete-jumpto_declaration_key*
 					*g:clang_jumpto_declaration_key*
 Set the key used to jump to declaration.

--- a/doc/clang_complete.txt
+++ b/doc/clang_complete.txt
@@ -180,6 +180,7 @@ Default: 'iunmap <buffer> <CR>'
        				       	*g:clang_close_preview*
 If equal to 1, the preview window will be close automatically after a
 completion.
+If equal to 2, the preview window won't even be opened.
 Default: 0
 
        				      	*clang_complete-user_options*

--- a/doc/clang_complete.txt
+++ b/doc/clang_complete.txt
@@ -273,6 +273,7 @@ Default: 0
 Set the key used to print the type of the identifier under cursor.
 If cursor is on an enum, then the value of that enum is also printed.
 Defaut: "zp"
+Note: You can call ClangPrintType() vim function to print this information.
 
 					*clang_complete-jumpto_declaration_key*
 					*g:clang_jumpto_declaration_key*

--- a/plugin/clang/cindex.py
+++ b/plugin/clang/cindex.py
@@ -1088,15 +1088,7 @@ class Cursor(Structure):
     def is_function(self):
         """Determine if cursor is over a function.
         """
-        return ( self.kind == CursorKind.FUNCTION_DECL or
-                 self.kind == CursorKind.OBJC_INSTANCE_METHOD_DECL or
-                 self.kind == CursorKind.OBJC_CLASS_METHOD_DECL or
-                 self.kind == CursorKind.CXX_METHOD or
-                 self.kind == CursorKind.CONSTRUCTOR or
-                 self.kind == CursorKind.DESTRUCTOR or
-                 self.kind == CursorKind.CONVERSION_FUNCTION or
-                 self.kind == CursorKind.FUNCTION_TEMPLATE or
-                 self.kind == CursorKind.CALL_EXPR )
+        return ( -1 != conf.lib.clang_Cursor_getNumArguments(self) )
 
     def is_static_method(self):
         """Returns True if the cursor refers to a C++ member function or member

--- a/plugin/clang/cindex.py
+++ b/plugin/clang/cindex.py
@@ -1580,6 +1580,15 @@ class Type(Structure):
         """
         return conf.lib.clang_getCanonicalType(self)
 
+    def get_spelling(self):
+        """
+        Pretty-print the underlying type using the rules of the
+        language of the translation unit from which it came.
+
+        If the type is invalid, an empty string is returned.
+        """
+        return conf.lib.clang_getTypeSpelling(self).decode("utf-8")
+
     def is_const_qualified(self):
         """Determine whether a Type has the "const" qualifier set.
 
@@ -2972,6 +2981,11 @@ functionList = [
 
   ("clang_getTypeKindSpelling",
    [c_uint],
+   _CXString,
+   _CXString.from_result),
+
+  ("clang_getTypeSpelling",
+   [Type],
    _CXString,
    _CXString.from_result),
 

--- a/plugin/clang/cindex.py
+++ b/plugin/clang/cindex.py
@@ -1078,6 +1078,13 @@ class Cursor(Structure):
         """
         return conf.lib.clang_isCursorDefinition(self)
 
+    def is_virtual_method(self):
+        """Determine if a C++ member function or member function template is
+        explicitly declared 'virtual' or if it overrides a virtual method from
+        one of the base classes.
+        """
+        return conf.lib.clang_CXXMethod_isVirtual(self)
+
     def is_static_method(self):
         """Returns True if the cursor refers to a C++ member function or member
         function template that is declared 'static'.

--- a/plugin/clang/cindex.py
+++ b/plugin/clang/cindex.py
@@ -1085,6 +1085,19 @@ class Cursor(Structure):
         """
         return conf.lib.clang_CXXMethod_isVirtual(self)
 
+    def is_function(self):
+        """Determine if cursor is over a function.
+        """
+        return ( self.kind == CursorKind.FUNCTION_DECL or
+                 self.kind == CursorKind.OBJC_INSTANCE_METHOD_DECL or
+                 self.kind == CursorKind.OBJC_CLASS_METHOD_DECL or
+                 self.kind == CursorKind.CXX_METHOD or
+                 self.kind == CursorKind.CONSTRUCTOR or
+                 self.kind == CursorKind.DESTRUCTOR or
+                 self.kind == CursorKind.CONVERSION_FUNCTION or
+                 self.kind == CursorKind.FUNCTION_TEMPLATE or
+                 self.kind == CursorKind.CALL_EXPR )
+
     def is_static_method(self):
         """Returns True if the cursor refers to a C++ member function or member
         function template that is declared 'static'.

--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -124,6 +124,10 @@ function! s:ClangCompleteInit()
     let g:clang_auto_user_options = '.clang_complete, path'
   endif
 
+  if !exists('g:clang_print_type_key')
+    let g:clang_print_type_key = 'zp'
+  endif
+
   if !exists('g:clang_jumpto_declaration_key')
     let g:clang_jumpto_declaration_key = '<C-]>'
   endif
@@ -191,6 +195,7 @@ function! s:ClangCompleteInit()
     inoremap <expr> <buffer> . <SID>CompleteDot()
     inoremap <expr> <buffer> > <SID>CompleteArrow()
     inoremap <expr> <buffer> : <SID>CompleteColon()
+    execute "nnoremap <buffer> <silent> " . g:clang_print_type_key . " :call <SID>PrintType()<CR><Esc>"
     execute "nnoremap <buffer> <silent> " . g:clang_jumpto_declaration_key . " :call <SID>GotoDeclaration(0)<CR><Esc>"
     execute "nnoremap <buffer> <silent> " . g:clang_jumpto_declaration_in_preview_key . " :call <SID>GotoDeclaration(1)<CR><Esc>"
     execute "nnoremap <buffer> <silent> " . g:clang_jumpto_back_key . " <C-O>"
@@ -632,6 +637,12 @@ function! s:CompleteColon()
     return ':'
   endif
   return ':' . s:LaunchCompletion()
+endfunction
+
+function! s:PrintType()
+    execute s:py_cmd "clangGetType()"
+    redraw
+    echom b:clang_type
 endfunction
 
 function! s:GotoDeclaration(preview)

--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -637,6 +637,13 @@ endfunction
 function! s:GotoDeclaration(preview)
   try
     execute s:py_cmd "gotoDeclaration(vim.eval('a:preview') == '1')"
+    if g:clang_is_virtual_method
+      redraw
+      echohl ErrorMsg | echom "This is a virtual function!" | echohl None
+    else
+      redraw
+      echom "non-virtual function"
+    endif
   catch /^Vim\%((\a\+)\)\=:E37/
     echoe "The current file is not saved, and 'hidden' is not set."
           \ "Either save the file or add 'set hidden' in your vimrc."

--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -640,9 +640,13 @@ function! s:GotoDeclaration(preview)
     if g:clang_is_virtual_method
       redraw
       echohl ErrorMsg | echom "This is a virtual function!" | echohl None
-    else
+    elseif g:clang_is_function
       redraw
       echom "non-virtual function"
+    else
+      " clear previous message
+      redraw
+      echom ""
     endif
   catch /^Vim\%((\a\+)\)\=:E37/
     echoe "The current file is not saved, and 'hidden' is not set."

--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -195,7 +195,7 @@ function! s:ClangCompleteInit()
     inoremap <expr> <buffer> . <SID>CompleteDot()
     inoremap <expr> <buffer> > <SID>CompleteArrow()
     inoremap <expr> <buffer> : <SID>CompleteColon()
-    execute "nnoremap <buffer> <silent> " . g:clang_print_type_key . " :call <SID>PrintType()<CR><Esc>"
+    execute "nnoremap <buffer> <silent> " . g:clang_print_type_key . " :call ClangPrintType()<CR><Esc>"
     execute "nnoremap <buffer> <silent> " . g:clang_jumpto_declaration_key . " :call <SID>GotoDeclaration(0)<CR><Esc>"
     execute "nnoremap <buffer> <silent> " . g:clang_jumpto_declaration_in_preview_key . " :call <SID>GotoDeclaration(1)<CR><Esc>"
     execute "nnoremap <buffer> <silent> " . g:clang_jumpto_back_key . " <C-O>"
@@ -639,7 +639,7 @@ function! s:CompleteColon()
   return ':' . s:LaunchCompletion()
 endfunction
 
-function! s:PrintType()
+function! ClangPrintType()
     execute s:py_cmd "clangGetType()"
     redraw
     echom b:clang_type

--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -207,6 +207,10 @@ function! s:ClangCompleteInit()
     set completeopt+=menuone
   endif
 
+  if g:clang_close_preview == 2
+    set completeopt-=preview
+  endif
+
   " Disable every autocmd that could have been set.
   augroup ClangComplete
     autocmd!
@@ -573,7 +577,7 @@ function! s:TriggerSnippet()
   " Trigger the snippet
   execute s:py_cmd 'snippetsTrigger()'
 
-  if g:clang_close_preview
+  if g:clang_close_preview == 1
     pclose
   endif
 endfunction

--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -78,6 +78,10 @@ function! s:ClangCompleteInit()
     let g:clang_snippets_engine = 'clang_complete'
   endif
 
+  if !exists('g:clang_complete_snippet_jump_map')
+    let g:clang_complete_snippet_jump_map = '<tab>'
+  endif
+
   if !exists('g:clang_user_options')
     let g:clang_user_options = ''
   endif
@@ -195,10 +199,18 @@ function! s:ClangCompleteInit()
     inoremap <expr> <buffer> . <SID>CompleteDot()
     inoremap <expr> <buffer> > <SID>CompleteArrow()
     inoremap <expr> <buffer> : <SID>CompleteColon()
-    execute "nnoremap <buffer> <silent> " . g:clang_print_type_key . " :call ClangPrintType()<CR><Esc>"
-    execute "nnoremap <buffer> <silent> " . g:clang_jumpto_declaration_key . " :call <SID>GotoDeclaration(0)<CR><Esc>"
-    execute "nnoremap <buffer> <silent> " . g:clang_jumpto_declaration_in_preview_key . " :call <SID>GotoDeclaration(1)<CR><Esc>"
-    execute "nnoremap <buffer> <silent> " . g:clang_jumpto_back_key . " <C-O>"
+    if g:clang_print_type_key != ""
+      execute "nnoremap <buffer> <silent> " . g:clang_print_type_key . " :call ClangPrintType()<CR><Esc>"
+    endif
+    if g:clang_jumpto_declaration_key != ""
+      execute "nnoremap <buffer> <silent> " . g:clang_jumpto_declaration_key . " :call <SID>GotoDeclaration(0)<CR><Esc>"
+    endif
+    if g:clang_jumpto_declaration_in_preview_key != ""
+      execute "nnoremap <buffer> <silent> " . g:clang_jumpto_declaration_in_preview_key . " :call <SID>GotoDeclaration(1)<CR><Esc>"
+    endif
+    if g:clang_jumpto_back_key != ""
+      execute "nnoremap <buffer> <silent> " . g:clang_jumpto_back_key . " <C-O>"
+    endif
   endif
 
   if g:clang_omnicppcomplete_compliance == 1

--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -434,7 +434,10 @@ def formatResult(result):
       for optional_arg in roll_out_optional(chunk.string):
         if place_markers_for_optional_args:
           word += snippetsFormatPlaceHolder(optional_arg)
-        info += optional_arg + "=?"
+        if -1 != optional_arg.find('='):
+          info += optional_arg
+        else:
+          info += optional_arg + "=?"
 
     if chunk.isKindPlaceHolder():
       word += snippetsFormatPlaceHolder(chunk_spelling)

--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -594,6 +594,9 @@ def gotoDeclaration(preview=True):
     f = File.from_name(tu, vim.current.buffer.name)
     loc = SourceLocation.from_position(tu, f, line, col + 1)
     cursor = Cursor.from_location(tu, loc)
+    vim.command("let g:clang_is_virtual_method = 0");
+    if cursor.is_virtual_method():
+      vim.command("let g:clang_is_virtual_method = 1");
     defs = [cursor.get_definition(), cursor.referenced]
 
     for d in defs:
@@ -601,6 +604,8 @@ def gotoDeclaration(preview=True):
         loc = d.location
         if loc.file is not None:
           jumpToLocation(loc.file.name, loc.line, loc.column, preview)
+          if d.is_virtual_method():
+            vim.command("let g:clang_is_virtual_method = 1");
         break
 
   timer.finish()

--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -595,8 +595,11 @@ def gotoDeclaration(preview=True):
     loc = SourceLocation.from_position(tu, f, line, col + 1)
     cursor = Cursor.from_location(tu, loc)
     vim.command("let g:clang_is_virtual_method = 0");
+    vim.command("let g:clang_is_function = 0");
     if cursor.is_virtual_method():
       vim.command("let g:clang_is_virtual_method = 1");
+    if cursor.is_function():
+      vim.command("let g:clang_is_function = 1");
     defs = [cursor.get_definition(), cursor.referenced]
 
     for d in defs:
@@ -606,6 +609,8 @@ def gotoDeclaration(preview=True):
           jumpToLocation(loc.file.name, loc.line, loc.column, preview)
           if d.is_virtual_method():
             vim.command("let g:clang_is_virtual_method = 1");
+          if d.is_function():
+            vim.command("let g:clang_is_function = 1");
         break
 
   timer.finish()

--- a/plugin/snippets/clang_complete.py
+++ b/plugin/snippets/clang_complete.py
@@ -2,9 +2,11 @@ import re
 import vim
 
 def snippetsInit():
-  python_cmd = vim.eval('s:py_cmd')
-  vim.command("noremap <silent> <buffer> <tab> :{} updateSnips()<CR>".format(python_cmd))
-  vim.command("snoremap <silent> <buffer> <tab> <ESC>:{} updateSnips()<CR>".format(python_cmd))
+  snippet_jump_map = vim.eval("g:clang_complete_snippet_jump_map")
+  if "" != snippet_jump_map:
+    python_cmd = vim.eval('s:py_cmd')
+    vim.command("noremap <silent> <buffer> {} :{} updateSnips()<CR>".format(snippet_jump_map, python_cmd))
+    vim.command("snoremap <silent> <buffer> {} <ESC>:{} updateSnips()<CR>".format(snippet_jump_map, python_cmd))
   if int(vim.eval("g:clang_conceal_snippets")) == 1:
     vim.command("syntax match placeHolder /\$`[^`]*`/ contains=placeHolderMark")
     vim.command("syntax match placeHolderMark contained /\$`/ conceal")


### PR DESCRIPTION
Following extra functionalities are implemented in separate commits:
  - Option to disable preview window.
  - When jumping to declaration print whether we go jump to a virtual method to warn user that actually other derived function could be called.
  - Possibility and keybinding to print type of identifiers and if identifier is an enum, then it's value as well.
  - Remove extra =? in optional argument in newer clang libraries, which supports printing default value.
  - Making it possible to disable/change the mappings.
