### PR TITLE
cc_args.py: update shebang for Python 3

### DIFF
--- a/bin/cc_args.py
+++ b/bin/cc_args.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #-*- coding: utf-8 -*-
 
 import sys


### PR DESCRIPTION
Python 2 is obsolete.

/usr/bin/env python3 seems to be the standard way to specify to run with Python 3.