### PR TITLE
CMake Improvements

### DIFF
--- a/bin/cc_args.py
+++ b/bin/cc_args.py
@@ -3,7 +3,7 @@
 
 import sys
 
-CONFIG_NAME = ".clang_complete"
+CONFIG_NAME = "../.clang_complete"
 
 def readConfiguration():
   try:

--- a/doc/clang_complete.txt
+++ b/doc/clang_complete.txt
@@ -326,6 +326,20 @@ After running this command, .clang_complete will be created or updated with
 new options. If you don't want to update an existing configuration file,
 delete it before running make.
 
+For modern CMake, we need to use CMAKE_<LANG>_COMPILER_LAUNCHER, e.g. : >
+ cmake -S . -B build \
+ -DCMAKE_BUILD_TYPE=Release \
+ -DCMAKE_C_COMPILER_LAUNCHER=$HOME/.vim/bin/cc_args.py \
+ -DCMAKE_CXX_COMPILER_LAUNCHER=$HOME/.vim/bin/cc_args.py \
+ && cmake --build build
+...for Release builds, or...: >
+ cmake -S . -B debug \
+ -DCMAKE_BUILD_TYPE=Debug \
+ -DCMAKE_C_COMPILER_LAUNCHER=$HOME/.vim/bin/cc_args.py \
+ -DCMAKE_CXX_COMPILER_LAUNCHER=$HOME/.vim/bin/cc_args.py \
+ && cmake --build debug
+...for Debug builds.
+
 ==============================================================================
 8. To do					*clang_complete-todo*
 


### PR DESCRIPTION
The first change is to place `.clang_complete` one step above the build directory, as opposed to inside the build directory itself, with the aim of allowing `clang_complete` to work more seamlessly from the get-go.

The second change is to update the documentation to help users using CMake, where the current commands did not work - the missing piece of the puzzle was [`CMAKE_<LANG>_COMPILER_LAUNCHER`](https://cmake.org/cmake/help/latest/envvar/CMAKE_LANG_COMPILER_LAUNCHER.html).